### PR TITLE
Reimplement horizontal continuous scrolling

### DIFF
--- a/lib/src/constants/enum.dart
+++ b/lib/src/constants/enum.dart
@@ -13,6 +13,8 @@ enum ReaderMode {
   continuousVertical,
   singleHorizontalLTR,
   singleHorizontalRTL,
+  continuousHorizontalLTR,
+  continuousHorizontalRTL,
   singleVertical,
   webtoon,
 }

--- a/lib/src/features/manga_book/domain/manga/manga_model.g.dart
+++ b/lib/src/features/manga_book/domain/manga/manga_model.g.dart
@@ -96,6 +96,8 @@ const _$ReaderModeEnumMap = {
   ReaderMode.continuousVertical: 'continuousVertical',
   ReaderMode.singleHorizontalLTR: 'singleHorizontalLTR',
   ReaderMode.singleHorizontalRTL: 'singleHorizontalRTL',
+  ReaderMode.continuousHorizontalLTR: 'continuousHorizontalLTR',
+  ReaderMode.continuousHorizontalRTL: 'continuousHorizontalRTL',
   ReaderMode.singleVertical: 'singleVertical',
   ReaderMode.webtoon: 'webtoon',
 };

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -16,7 +16,7 @@ import '../../domain/chapter_patch/chapter_put_model.dart';
 import '../manga_details/controller/manga_details_controller.dart';
 import 'controller/reader_controller.dart';
 import 'widgets/reader_mode/single_page_reader_mode.dart';
-import 'widgets/reader_mode/webtoon_reader_mode.dart';
+import 'widgets/reader_mode/continuous_reader_mode.dart';
 
 class ReaderScreen extends HookConsumerWidget {
   const ReaderScreen({
@@ -88,6 +88,21 @@ class ReaderScreen extends HookConsumerWidget {
                       onPageChanged: onPageChanged,
                       reverse: true,
                     );
+                  case ReaderMode.continuousHorizontalLTR:
+                    return ContinuousReaderMode(
+                      chapter: chapterData,
+                      manga: data,
+                      onPageChanged: onPageChanged,
+                      scrollDirection: Axis.horizontal,
+                    );
+                  case ReaderMode.continuousHorizontalRTL:
+                    return ContinuousReaderMode(
+                      chapter: chapterData,
+                      manga: data,
+                      onPageChanged: onPageChanged,
+                      scrollDirection: Axis.horizontal,
+                      reverse: true,
+                    );
                   case ReaderMode.singleHorizontalLTR:
                     return SinglePageReaderMode(
                       chapter: chapterData,
@@ -95,7 +110,7 @@ class ReaderScreen extends HookConsumerWidget {
                       onPageChanged: onPageChanged,
                     );
                   case ReaderMode.continuousVertical:
-                    return WebtoonReaderMode(
+                    return ContinuousReaderMode(
                       chapter: chapterData,
                       manga: data,
                       onPageChanged: onPageChanged,
@@ -103,7 +118,7 @@ class ReaderScreen extends HookConsumerWidget {
                     );
                   case ReaderMode.webtoon:
                   default:
-                    return WebtoonReaderMode(
+                    return ContinuousReaderMode(
                       chapter: chapterData,
                       manga: data,
                       onPageChanged: onPageChanged,

--- a/lib/src/features/manga_book/presentation/reader/widgets/chapter_separator.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chapter_separator.dart
@@ -16,6 +16,7 @@ class ChapterSeparator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         KSizedBox.h16.size,


### PR DESCRIPTION
Renamed `WebtoonReaderMode` to `ContinuousReaderMode`.
Added `scrollDirection` and `reverse` parameters that get passed to to `ScrollablePositionedList`.
Changed the container with `ChapterSeperator` from `Column` to `Flex` with explicit direction.
Made `ChapterSeperator` vertically centered when displayed horizontally.
Made image fit dependent on flow direction.