### PR TITLE
Change Winget & Homebrew publish job to `ubuntu-latest`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -174,7 +174,7 @@ jobs:
 
   winget-publish:
     needs: create-build
-    runs-on: windows-latest # action can only be run on windows
+    runs-on: ubuntu-latest
     steps:
       - name: Update WINGET manifest
         uses: vedantmgoyal2009/winget-releaser@v2
@@ -185,7 +185,7 @@ jobs:
 
   homebrew-cask-publish:
     needs: create-build
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Update Homebrew cask
         uses: macauley/action-homebrew-bump-cask@v1


### PR DESCRIPTION
Winget Releaser now supports non-Windows runners, and `ubuntu-latest` is generally faster. Apply the same for Homebrew.