### PR TITLE
Add Reading History Feature

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -52,6 +52,8 @@ enum DBKeys {
   hideEmptyCategory(false),
   pinchToZoom(true),
   flexScheme(FlexScheme.material),
+  historyEnabled(true),
+  historyRetentionDays(90),
   ;
 
   const DBKeys(this.initial);

--- a/lib/src/features/history/data/graphql/query.graphql
+++ b/lib/src/features/history/data/graphql/query.graphql
@@ -1,0 +1,19 @@
+query GetReadingHistory(
+  $first: Int,
+  $offset: Int,
+  $after: Cursor,
+  $before: Cursor,
+  $filter: ChapterFilterInput,
+  $order: [ChapterOrderInput!]
+) {
+  chapters(
+    first: $first
+    offset: $offset
+    after: $after
+    before: $before
+    filter: $filter
+    order: $order
+  ) {
+    ...ChapterPageWithMangaDto
+  }
+} 

--- a/lib/src/features/history/data/history_repository.dart
+++ b/lib/src/features/history/data/history_repository.dart
@@ -1,0 +1,225 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../global_providers/global_providers.dart';
+import '../../../graphql/__generated__/schema.graphql.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../manga_book/data/manga_book/manga_book_repository.dart';
+import '../../manga_book/domain/chapter_batch/chapter_batch_model.dart';
+import '../../manga_book/domain/chapter_page/chapter_page_model.dart';
+import '../domain/history_item.dart';
+import 'graphql/__generated__/query.graphql.dart';
+
+part 'history_repository.g.dart';
+
+class HistoryRepository {
+  const HistoryRepository(this.client, this.mangaBookRepository);
+  final GraphQLClient client;
+  final MangaBookRepository mangaBookRepository;
+
+  /// Fetch reading history with pagination and filtering
+  Future<ChapterPageWithMangaDto?> getReadingHistory({
+    int pageSize = 50,
+    int pageNo = 0,
+    String? searchQuery,
+    DateTime? fromDate,
+    DateTime? toDate,
+  }) async {
+    // Build filter for chapters with actual reading progress
+    final filter = Input$ChapterFilterInput(
+      // Only get chapters from library manga
+      inLibrary: Input$BooleanFilterInput(equalTo: true),
+      // Only get chapters that have been read (lastReadAt is not null/empty)
+      lastReadAt: Input$LongFilterInput(
+        isNull: false,
+        greaterThan:
+            "0", // Ensure lastReadAt is actually set to a real timestamp
+      ),
+      // Only show chapters that have actual reading progress:
+      // Either fully read OR have made progress beyond the first page
+      or: [
+        // Fully completed chapters
+        Input$ChapterFilterInput(
+          isRead: Input$BooleanFilterInput(equalTo: true),
+        ),
+        // Chapters with meaningful reading progress (at least 1 page read)
+        Input$ChapterFilterInput(
+          lastPageRead: Input$IntFilterInput(greaterThan: 0),
+        ),
+      ],
+      // Additional filters
+      and: [
+        // Add date range filtering if provided
+        if (fromDate != null)
+          Input$ChapterFilterInput(
+            lastReadAt: Input$LongFilterInput(
+              greaterThanOrEqualTo: fromDate.millisecondsSinceEpoch.toString(),
+            ),
+          ),
+        if (toDate != null)
+          Input$ChapterFilterInput(
+            lastReadAt: Input$LongFilterInput(
+              lessThanOrEqualTo: toDate.millisecondsSinceEpoch.toString(),
+            ),
+          ),
+        // Add search filtering if provided
+        if (searchQuery.isNotBlank)
+          Input$ChapterFilterInput(
+            or: [
+              // Search in chapter name
+              Input$ChapterFilterInput(
+                name: Input$StringFilterInput(
+                  includesInsensitive: searchQuery,
+                ),
+              ),
+              // Note: We can't search manga title directly in chapter filter
+              // This will be handled in the UI layer
+            ],
+          ),
+      ],
+    );
+
+    // Order by lastReadAt descending (most recent first)
+    final order = [
+      Input$ChapterOrderInput(
+        by: Enum$ChapterOrderBy.LAST_READ_AT,
+        byType: Enum$SortOrder.DESC,
+      ),
+      // Secondary sort by source order for consistency
+      Input$ChapterOrderInput(
+        by: Enum$ChapterOrderBy.SOURCE_ORDER,
+        byType: Enum$SortOrder.DESC,
+      ),
+    ];
+
+    final result = await client
+        .query$GetReadingHistory(
+          Options$Query$GetReadingHistory(
+            variables: Variables$Query$GetReadingHistory(
+              first: pageSize * 10, // Get more results to filter duplicates
+              offset: pageNo * pageSize,
+              filter: filter,
+              order: order,
+            ),
+          ),
+        )
+        .getData((data) => data.chapters);
+
+    // Filter to only show the most recent chapter per manga
+    if (result?.nodes != null) {
+      // First, apply client-side filtering to ensure removed chapters are excluded
+      final validChapters = result!.nodes.where((chapter) {
+        // Only include chapters with actual reading progress:
+        // 1. Fully read chapters (isRead: true), OR
+        // 2. Chapters with meaningful progress (lastPageRead > 0)
+        // This excludes chapters that were removed from history (isRead: false AND lastPageRead: 0)
+        final isFullyRead = chapter.isRead;
+        final hasProgress = chapter.lastPageRead > 0;
+
+        return isFullyRead || hasProgress;
+      }).toList();
+
+      final Map<int, HistoryItemDto> latestChapterPerManga = {};
+
+      for (final chapter in validChapters) {
+        final mangaId = chapter.mangaId;
+
+        // Only keep the first (most recent) chapter for each manga
+        if (!latestChapterPerManga.containsKey(mangaId)) {
+          latestChapterPerManga[mangaId] = chapter;
+        }
+      }
+
+      // Take only the requested page size from the filtered results
+      final filteredChapters = latestChapterPerManga.values.toList()
+        ..sort((a, b) {
+          final aTime = a.readAt?.millisecondsSinceEpoch ?? 0;
+          final bTime = b.readAt?.millisecondsSinceEpoch ?? 0;
+          return bTime.compareTo(aTime); // Most recent first
+        });
+
+      final startIndex = pageNo * pageSize;
+      final endIndex =
+          (startIndex + pageSize).clamp(0, filteredChapters.length);
+      final pageChapters = startIndex < filteredChapters.length
+          ? filteredChapters.sublist(startIndex, endIndex)
+          : <HistoryItemDto>[];
+
+      return ChapterPageWithMangaDto(
+        nodes: pageChapters,
+        pageInfo: result.pageInfo,
+        totalCount: latestChapterPerManga.length,
+      );
+    }
+
+    return result;
+  }
+
+  /// Get reading history for a specific manga
+  Future<List<HistoryItemDto>?> getMangaReadingHistory({
+    required int mangaId,
+    int limit = 20,
+  }) async {
+    final filter = Input$ChapterFilterInput(
+      mangaId: Input$IntFilterInput(equalTo: mangaId),
+      lastReadAt: Input$LongFilterInput(isNull: false),
+    );
+
+    final order = [
+      Input$ChapterOrderInput(
+        by: Enum$ChapterOrderBy.LAST_READ_AT,
+        byType: Enum$SortOrder.DESC,
+      ),
+    ];
+
+    return client
+        .query$GetReadingHistory(
+          Options$Query$GetReadingHistory(
+            variables: Variables$Query$GetReadingHistory(
+              first: limit,
+              filter: filter,
+              order: order,
+            ),
+          ),
+        )
+        .getData((data) => data.chapters.nodes);
+  }
+
+  /// Clear reading history for a specific chapter
+  Future<void> removeChapterFromHistory(int chapterId) async {
+    // Mark the chapter as unread and reset progress
+    // This should remove it from history queries since our filter requires:
+    // either isRead: true OR lastPageRead > 0
+    await mangaBookRepository.putChapter(
+      chapterId: chapterId,
+      patch: ChapterChange(
+        isRead: false, // Set to false (not fully read)
+        lastPageRead: 0, // Reset to 0 (no progress)
+        // Note: lastReadAt cannot be cleared via this API
+        // Some chapters may still appear until server is restarted
+      ),
+    );
+  }
+
+  /// Clear all reading history (mark all chapters as unread)
+  /// This is a destructive operation and should be used with caution
+  Future<void> clearAllHistory() async {
+    // This would require a server-side bulk operation
+    // For now, this is a placeholder that would need server support
+    throw UnimplementedError(
+      'Clearing all history requires server-side support. '
+      'Please use individual chapter removal instead.',
+    );
+  }
+}
+
+@riverpod
+HistoryRepository historyRepository(Ref ref) => HistoryRepository(
+    ref.watch(graphQlClientProvider), ref.watch(mangaBookRepositoryProvider));

--- a/lib/src/features/history/domain/history_group.dart
+++ b/lib/src/features/history/domain/history_group.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'history_item.dart';
+
+part 'history_group.freezed.dart';
+
+@freezed
+class HistoryGroup with _$HistoryGroup {
+  const factory HistoryGroup({
+    required String title,
+    required List<HistoryItemDto> items,
+  }) = _HistoryGroup;
+
+  const HistoryGroup._();
+
+  /// Get the total number of items in this group
+  int get itemCount => items.length;
+
+  /// Check if this group is empty
+  bool get isEmpty => items.isEmpty;
+
+  /// Check if this group is not empty
+  bool get isNotEmpty => items.isNotEmpty;
+
+  /// Get the most recent read date in this group
+  DateTime? get mostRecentReadDate {
+    if (items.isEmpty) return null;
+
+    DateTime? mostRecent;
+    for (final item in items) {
+      final readDate = item.readAt;
+      if (readDate != null) {
+        if (mostRecent == null || readDate.isAfter(mostRecent)) {
+          mostRecent = readDate;
+        }
+      }
+    }
+    return mostRecent;
+  }
+
+  /// Filter items in this group by search query
+  HistoryGroup filterByQuery(String? query) {
+    if (query == null || query.trim().isEmpty) return this;
+
+    final filteredItems = items.where((HistoryItemDto item) {
+      if (query.trim().isEmpty) return true;
+      final searchQuery = query.toLowerCase();
+
+      return item.manga.title.toLowerCase().contains(searchQuery) ||
+          item.name.toLowerCase().contains(searchQuery) ||
+          (item.manga.author?.toLowerCase().contains(searchQuery) ?? false) ||
+          (item.scanlator?.toLowerCase().contains(searchQuery) ?? false);
+    }).toList();
+    return copyWith(items: filteredItems);
+  }
+}

--- a/lib/src/features/history/domain/history_item.dart
+++ b/lib/src/features/history/domain/history_item.dart
@@ -1,0 +1,116 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../manga_book/domain/chapter/chapter_model.dart';
+
+// Use existing ChapterWithMangaDto as the base for history items
+// since it already contains all the data we need including lastReadAt
+typedef HistoryItemDto = ChapterWithMangaDto;
+
+extension HistoryItemExtension on HistoryItemDto {
+  /// Get the read timestamp as DateTime
+  DateTime? get readAt {
+    final timestamp = lastReadAt;
+    if (timestamp.isBlank) return null;
+    final milliseconds = int.tryParse(timestamp);
+    if (milliseconds == null || milliseconds <= 0) return null;
+
+    // Try parsing as milliseconds first, then as seconds if the result is too old
+    var dateTime = DateTime.fromMillisecondsSinceEpoch(milliseconds);
+
+    // If the parsed date is before 1990, it's likely in seconds format
+    if (dateTime.year < 1990) {
+      dateTime = DateTime.fromMillisecondsSinceEpoch(milliseconds * 1000);
+    }
+
+    // If still before 1990, something is wrong with the data
+    if (dateTime.year < 1990) {
+      return null;
+    }
+
+    return dateTime;
+  }
+
+  /// Check if this item was read today
+  bool get isReadToday {
+    final readDate = readAt;
+    if (readDate == null) return false;
+    final now = DateTime.now();
+    return readDate.year == now.year &&
+        readDate.month == now.month &&
+        readDate.day == now.day;
+  }
+
+  /// Check if this item was read yesterday
+  bool get isReadYesterday {
+    final readDate = readAt;
+    if (readDate == null) return false;
+    final yesterday = DateTime.now().subtract(const Duration(days: 1));
+    return readDate.year == yesterday.year &&
+        readDate.month == yesterday.month &&
+        readDate.day == yesterday.day;
+  }
+
+  /// Get a formatted date string for grouping (by day)
+  String get readDateGroup {
+    final readDate = readAt;
+    if (readDate == null) {
+      return 'Recently Read';
+    }
+
+    if (isReadToday) return 'Today';
+    if (isReadYesterday) return 'Yesterday';
+
+    final now = DateTime.now();
+    final difference = now.difference(readDate).inDays;
+
+    if (difference < 0) {
+      // Future date (shouldn't happen but handle gracefully)
+      return 'Recently Read';
+    } else if (difference < 7) {
+      // Show specific days for the past week
+      final weekdays = [
+        'Monday',
+        'Tuesday',
+        'Wednesday',
+        'Thursday',
+        'Friday',
+        'Saturday',
+        'Sunday'
+      ];
+      return weekdays[readDate.weekday - 1];
+    } else {
+      // For older items, show the specific date
+      final months = [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December'
+      ];
+      return '${months[readDate.month - 1]} ${readDate.day}, ${readDate.year}';
+    }
+  }
+
+  /// Search functionality for history items
+  bool historyQuery([String? query]) {
+    if (query.isBlank) return true;
+    final searchQuery = query!.toLowerCase();
+
+    return manga.title.toLowerCase().contains(searchQuery) ||
+        name.toLowerCase().contains(searchQuery) ||
+        (manga.author?.toLowerCase().contains(searchQuery) ?? false) ||
+        (scanlator?.toLowerCase().contains(searchQuery) ?? false);
+  }
+}

--- a/lib/src/features/history/presentation/history_controller.dart
+++ b/lib/src/features/history/presentation/history_controller.dart
@@ -1,0 +1,213 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../constants/db_keys.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../../utils/mixin/shared_preferences_client_mixin.dart';
+import '../../manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import '../data/history_repository.dart';
+import '../domain/history_group.dart';
+import '../domain/history_item.dart';
+
+part 'history_controller.g.dart';
+
+@riverpod
+class ReadingHistory extends _$ReadingHistory {
+  @override
+  Future<List<HistoryItemDto>?> build() async {
+    final result =
+        await ref.watch(historyRepositoryProvider).getReadingHistory();
+    ref.keepAlive();
+    return result?.nodes;
+  }
+
+  Future<void> refresh() async {
+    state = const AsyncLoading();
+
+    final result = await AsyncValue.guard(
+      () => ref.read(historyRepositoryProvider).getReadingHistory(),
+    );
+
+    ref.keepAlive();
+    if (result.hasError) {
+      state = AsyncValue.error(result.error!, result.stackTrace!);
+    } else {
+      state = AsyncData(result.value?.nodes);
+    }
+  }
+
+  Future<void> loadMore() async {
+    final currentItems = state.valueOrNull ?? [];
+    final pageNo = (currentItems.length / 50).floor() + 1;
+
+    final result = await AsyncValue.guard(
+      () =>
+          ref.read(historyRepositoryProvider).getReadingHistory(pageNo: pageNo),
+    );
+
+    if (result.hasValue && result.value?.nodes != null) {
+      final newItems = result.value?.nodes ?? [];
+      final updatedItems = [...currentItems, ...newItems];
+      state = AsyncData(updatedItems);
+    } else if (result.hasError) {
+      state = AsyncValue.error(result.error!, result.stackTrace!);
+    }
+  }
+
+  /// Remove a chapter from reading history
+  Future<void> removeFromHistory(int chapterId) async {
+    state = await AsyncValue.guard(() async {
+      // First get the chapter to extract mangaId for cache invalidation
+      final currentItems = state.valueOrNull ?? [];
+      HistoryItemDto? chapterToRemove;
+
+      try {
+        chapterToRemove =
+            currentItems.firstWhere((item) => item.id == chapterId);
+      } catch (e) {
+        // Chapter not found in current list, continue anyway
+      }
+
+      // Remove the chapter from history on the server
+      await ref
+          .read(historyRepositoryProvider)
+          .removeChapterFromHistory(chapterId);
+
+      // Invalidate all related caches to ensure fresh data
+      if (chapterToRemove != null) {
+        final mangaId = chapterToRemove.mangaId;
+        // Invalidate the specific manga's chapter list so it shows as unread immediately
+        ref.invalidate(mangaChapterListProvider(mangaId: mangaId));
+        ref.invalidate(mangaWithIdProvider(mangaId: mangaId));
+      }
+
+      // Also invalidate the history provider itself to force a fresh query
+      ref.invalidateSelf();
+
+      // Refresh the history data from server to get updated state
+      final result =
+          await ref.read(historyRepositoryProvider).getReadingHistory();
+      return result?.nodes;
+    });
+  }
+}
+
+@riverpod
+class MangaReadingHistory extends _$MangaReadingHistory {
+  @override
+  Future<List<HistoryItemDto>?> build({required int mangaId}) async {
+    return ref
+        .watch(historyRepositoryProvider)
+        .getMangaReadingHistory(mangaId: mangaId);
+  }
+
+  Future<void> refresh() async {
+    final result = await AsyncValue.guard(
+      () => ref
+          .read(historyRepositoryProvider)
+          .getMangaReadingHistory(mangaId: mangaId),
+    );
+
+    if (result.hasError) {
+      state = AsyncValue.error(result.error!, result.stackTrace!);
+    } else {
+      state = result;
+    }
+  }
+}
+
+@riverpod
+List<HistoryGroup> historyGroupedByDate(Ref ref) {
+  final historyItems = ref.watch(readingHistoryProvider).valueOrNull ?? [];
+
+  if (historyItems.isEmpty) return [];
+
+  // Group items by their read date
+  final Map<String, List<HistoryItemDto>> groupedItems = {};
+
+  for (final item in historyItems) {
+    final groupKey = item.readDateGroup;
+    groupedItems.putIfAbsent(groupKey, () => []).add(item);
+  }
+
+  // Convert to HistoryGroup objects and sort by most recent
+  final groups = groupedItems.entries.map((entry) {
+    return HistoryGroup(
+      title: entry.key,
+      items: entry.value,
+    );
+  }).toList();
+
+  // Sort groups by most recent read date
+  groups.sort((a, b) {
+    final aDate = a.mostRecentReadDate;
+    final bDate = b.mostRecentReadDate;
+
+    if (aDate == null && bDate == null) return 0;
+    if (aDate == null) return 1;
+    if (bDate == null) return -1;
+
+    return bDate.compareTo(aDate); // Most recent first
+  });
+
+  return groups;
+}
+
+@riverpod
+List<HistoryGroup> filteredHistoryGroups(Ref ref) {
+  final groups = ref.watch(historyGroupedByDateProvider);
+  final searchQuery = ref.watch(historySearchQueryProvider);
+
+  if (searchQuery.isBlank) return groups;
+
+  // Filter each group and remove empty groups
+  final filteredGroups = groups
+      .map((group) => group.filterByQuery(searchQuery))
+      .where((group) => group.isNotEmpty)
+      .toList();
+
+  return filteredGroups;
+}
+
+@riverpod
+class HistorySearchQuery extends _$HistorySearchQuery {
+  @override
+  String build() => '';
+
+  void updateQuery(String query) {
+    state = query;
+  }
+
+  void clearQuery() {
+    state = '';
+  }
+}
+
+// History settings providers
+@riverpod
+class HistoryRetentionDays extends _$HistoryRetentionDays
+    with SharedPreferenceClientMixin<int> {
+  @override
+  int? build() => initialize(DBKeys.historyRetentionDays);
+
+  void updateRetentionDays(int days) {
+    update(days);
+  }
+}
+
+@riverpod
+class HistoryEnabled extends _$HistoryEnabled
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.historyEnabled);
+
+  void toggleHistory() {
+    update(!(state ?? true));
+  }
+}

--- a/lib/src/features/history/presentation/history_screen.dart
+++ b/lib/src/features/history/presentation/history_screen.dart
@@ -1,0 +1,199 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../l10n/generated/app_localizations.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../../widgets/emoticons.dart';
+import '../../../widgets/search_field.dart';
+import 'history_controller.dart';
+import 'widgets/history_group_widget.dart';
+
+class HistoryScreen extends ConsumerWidget {
+  const HistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final historyGroups = ref.watch(filteredHistoryGroupsProvider);
+    final historyState = ref.watch(readingHistoryProvider);
+    final searchQuery = ref.watch(historySearchQueryProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.history),
+        actions: [
+          IconButton(
+            onPressed: () =>
+                ref.read(readingHistoryProvider.notifier).refresh(),
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          // Search bar
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: SearchField(
+              initialText: searchQuery,
+              onChanged: (query) => ref
+                  .read(historySearchQueryProvider.notifier)
+                  .updateQuery(query ?? ''),
+              onSubmitted: (query) => ref
+                  .read(historySearchQueryProvider.notifier)
+                  .updateQuery(query ?? ''),
+              hintText: l10n.searchHistory,
+            ),
+          ),
+          // History content
+          Expanded(
+            child: historyState.when(
+              data: (data) {
+                if (data == null || data.isEmpty) {
+                  return _buildEmptyState(context, l10n);
+                }
+
+                if (historyGroups.isEmpty && searchQuery.isNotBlank) {
+                  return _buildNoSearchResults(context, l10n);
+                }
+
+                return RefreshIndicator(
+                  onRefresh: () =>
+                      ref.read(readingHistoryProvider.notifier).refresh(),
+                  child: ListView.builder(
+                    padding: const EdgeInsets.all(8),
+                    itemCount: historyGroups.length,
+                    itemBuilder: (context, index) {
+                      final group = historyGroups[index];
+                      return HistoryGroupWidget(
+                        group: group,
+                        onRemoveItem: (chapterId) => ref
+                            .read(readingHistoryProvider.notifier)
+                            .removeFromHistory(chapterId),
+                      );
+                    },
+                  ),
+                );
+              },
+              loading: () => const Center(
+                child: CircularProgressIndicator(),
+              ),
+              error: (error, stack) => _buildErrorState(
+                context,
+                l10n,
+                error,
+                () => ref.read(readingHistoryProvider.notifier).refresh(),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context, AppLocalizations l10n) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Emoticons(
+              iconData: Icons.history,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              l10n.noHistoryFound,
+              style: context.theme.textTheme.headlineSmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.startReadingToSeeHistory,
+              style: context.theme.textTheme.bodyMedium?.copyWith(
+                color: context.theme.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNoSearchResults(BuildContext context, AppLocalizations l10n) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Emoticons(
+              iconData: Icons.search_off,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              l10n.noSearchResults,
+              style: context.theme.textTheme.headlineSmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.tryDifferentSearchTerm,
+              style: context.theme.textTheme.bodyMedium?.copyWith(
+                color: context.theme.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildErrorState(
+    BuildContext context,
+    AppLocalizations l10n,
+    Object error,
+    VoidCallback onRetry,
+  ) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Emoticons(
+              iconData: Icons.error_outline,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              l10n.errorOccurred,
+              style: context.theme.textTheme.headlineSmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              error.toString(),
+              style: context.theme.textTheme.bodyMedium?.copyWith(
+                color: context.theme.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: onRetry,
+              child: Text(l10n.retry),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/history/presentation/widgets/history_group_widget.dart
+++ b/lib/src/features/history/presentation/widgets/history_group_widget.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+
+import '../../../../utils/extensions/custom_extensions.dart';
+import '../../domain/history_group.dart';
+import '../../domain/history_item.dart';
+import 'history_item_tile.dart';
+
+class HistoryGroupWidget extends StatelessWidget {
+  const HistoryGroupWidget({
+    super.key,
+    required this.group,
+    required this.onRemoveItem,
+  });
+
+  final HistoryGroup group;
+  final Function(int chapterId) onRemoveItem;
+
+  @override
+  Widget build(BuildContext context) {
+    if (group.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Group header
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: 8,
+            vertical: 12,
+          ),
+          child: Row(
+            children: [
+              Text(
+                group.title,
+                style: context.theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: context.theme.colorScheme.primary,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 8,
+                  vertical: 2,
+                ),
+                decoration: BoxDecoration(
+                  color: context.theme.colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  '${group.itemCount}',
+                  style: context.theme.textTheme.labelSmall?.copyWith(
+                    color: context.theme.colorScheme.onPrimaryContainer,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        // Group items
+        ...group.items.map((HistoryItemDto item) => HistoryItemTile(
+              item: item,
+              onRemove: () => onRemoveItem(item.id),
+            )),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+}

--- a/lib/src/features/history/presentation/widgets/history_item_tile.dart
+++ b/lib/src/features/history/presentation/widgets/history_item_tile.dart
@@ -1,0 +1,215 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../routes/router_config.dart';
+import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../../widgets/server_image.dart';
+import '../../domain/history_item.dart';
+
+class HistoryItemTile extends StatelessWidget {
+  const HistoryItemTile({
+    super.key,
+    required this.item,
+    this.onTap,
+    required this.onRemove,
+  });
+
+  final HistoryItemDto item;
+  final VoidCallback? onTap;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    final readDate = item.readAt;
+    final timeString = readDate != null ? DateFormat.Hm().format(readDate) : '';
+
+    return Card(
+      margin: const EdgeInsets.symmetric(
+        horizontal: 4,
+        vertical: 2,
+      ),
+      child: InkWell(
+        onTap: onTap ?? () => _navigateToReader(context),
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Row(
+            children: [
+              // Manga cover
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: ServerImage(
+                  imageUrl: item.manga.thumbnailUrl ?? "",
+                  size: const Size(56, 80),
+                ),
+              ),
+              const SizedBox(width: 12),
+              // Content
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Manga title
+                    Text(
+                      item.manga.title,
+                      style: context.theme.textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    // Chapter name
+                    Text(
+                      item.name,
+                      style: context.theme.textTheme.bodyMedium?.copyWith(
+                        color: context.theme.colorScheme.onSurfaceVariant,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    // Reading info
+                    Row(
+                      children: [
+                        // Read time
+                        if (timeString.isNotEmpty) ...[
+                          Icon(
+                            Icons.access_time,
+                            size: 14,
+                            color: context.theme.colorScheme.onSurfaceVariant,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            timeString,
+                            style: context.theme.textTheme.labelSmall?.copyWith(
+                              color: context.theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                        // Progress indicator
+                        if (item.lastPageRead > 0 && item.pageCount > 0) ...[
+                          const SizedBox(width: 8),
+                          Icon(
+                            Icons.bookmark,
+                            size: 14,
+                            color: context.theme.colorScheme.primary,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            '${item.lastPageRead}/${item.pageCount}',
+                            style: context.theme.textTheme.labelSmall?.copyWith(
+                              color: context.theme.colorScheme.primary,
+                            ),
+                          ),
+                        ],
+                        // Scanlator
+                        if (item.scanlator.isNotBlank) ...[
+                          const SizedBox(width: 8),
+                          Flexible(
+                            child: Text(
+                              item.scanlator!,
+                              style:
+                                  context.theme.textTheme.labelSmall?.copyWith(
+                                color:
+                                    context.theme.colorScheme.onSurfaceVariant,
+                                fontStyle: FontStyle.italic,
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              // Actions
+              PopupMenuButton<String>(
+                icon: Icon(
+                  Icons.more_vert,
+                  color: context.theme.colorScheme.onSurfaceVariant,
+                ),
+                onSelected: (value) {
+                  switch (value) {
+                    case 'remove':
+                      _showRemoveDialog(context);
+                      break;
+                    case 'manga':
+                      _navigateToManga(context);
+                      break;
+                  }
+                },
+                itemBuilder: (context) => [
+                  PopupMenuItem(
+                    value: 'manga',
+                    child: Row(
+                      children: [
+                        const Icon(Icons.book),
+                        const SizedBox(width: 8),
+                        Text(context.l10n.viewManga),
+                      ],
+                    ),
+                  ),
+                  PopupMenuItem(
+                    value: 'remove',
+                    child: Row(
+                      children: [
+                        const Icon(Icons.delete_outline),
+                        const SizedBox(width: 8),
+                        Text(context.l10n.removeFromHistory),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _showRemoveDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(context.l10n.removeFromHistory),
+        content: Text(context.l10n.removeFromHistoryConfirmation),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(context.l10n.cancel),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              onRemove();
+            },
+            child: Text(context.l10n.remove),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _navigateToReader(BuildContext context) {
+    // Navigate to the reader, continuing from where the user left off
+    ReaderRoute(
+      mangaId: item.mangaId,
+      chapterId: item.id,
+    ).push(context);
+  }
+
+  void _navigateToManga(BuildContext context) {
+    // Navigate to the manga details page
+    MangaRoute(mangaId: item.mangaId).push(context);
+  }
+}

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -45,27 +45,36 @@ class ReaderScreen extends HookConsumerWidget {
 
     final updateLastRead = useCallback((int currentPage) async {
       final chapterValue = chapter.valueOrNull;
-      if (chapterValue == null) return;
+      final chapterPagesValue = chapterPages.valueOrNull;
+      if (chapterValue == null || chapterPagesValue == null) return;
 
-      final isReadingCompeted = ((chapterValue.isRead).ifNull() ||
-          (currentPage >=
-              ((chapterValue.pageCount).getValueOnNullOrNegative() - 1)));
+      // Use the actual loaded pages count, not the chapter's pageCount metadata
+      final actualPageCount = chapterPagesValue.pages.length;
+
+      // Only mark as completed if we've reached the actual last page
+      final isReadingCompleted =
+          (currentPage >= (actualPageCount - 1)) && actualPageCount > 0;
+
       await AsyncValue.guard(
         () => ref.read(mangaBookRepositoryProvider).putChapter(
               chapterId: chapterValue.id,
               patch: ChapterChange(
-                lastPageRead: isReadingCompeted ? 0 : currentPage,
-                isRead: isReadingCompeted,
+                lastPageRead: isReadingCompleted ? 0 : currentPage,
+                isRead: isReadingCompleted,
               ),
             ),
       );
-    }, [chapter.valueOrNull]);
+    }, [chapter.valueOrNull, chapterPages.valueOrNull]);
 
     final onPageChanged = useCallback<AsyncValueSetter<int>>(
       (int index) async {
         final chapterValue = chapter.valueOrNull;
-        if ((chapterValue?.isRead).ifNull() ||
-            (chapterValue?.lastPageRead).getValueOnNullOrNegative() >= index) {
+        final chapterPagesValue = chapterPages.valueOrNull;
+        if (chapterValue == null || chapterPagesValue == null) return;
+
+        // Skip if chapter is already read or if we're going backwards
+        if ((chapterValue.isRead).ifNull() ||
+            (chapterValue.lastPageRead).getValueOnNullOrNegative() >= index) {
           return;
         }
 
@@ -74,9 +83,10 @@ class ReaderScreen extends HookConsumerWidget {
           finalDebounce?.cancel();
         }
 
-        if ((index >=
-            ((chapter.valueOrNull?.pageCount).getValueOnNullOrNegative() -
-                1))) {
+        // Use actual loaded pages count instead of chapter metadata
+        final actualPageCount = chapterPagesValue.pages.length;
+
+        if (index >= (actualPageCount - 1) && actualPageCount > 0) {
           updateLastRead(index);
         } else {
           debounce.value = Timer(
@@ -86,7 +96,7 @@ class ReaderScreen extends HookConsumerWidget {
         }
         return;
       },
-      [chapter],
+      [chapter, chapterPages],
     );
 
     useEffect(() {

--- a/lib/src/features/settings/presentation/more/more_screen.dart
+++ b/lib/src/features/settings/presentation/more/more_screen.dart
@@ -38,6 +38,11 @@ class MoreScreen extends ConsumerWidget {
             leading: const Icon(Icons.label_rounded),
             onTap: () => const EditCategoriesRoute().push(context),
           ),
+          ListTile(
+            title: Text(context.l10n.history),
+            leading: const Icon(Icons.history_rounded),
+            onTap: () => const HistoryRoute().go(context),
+          ),
           const AppThemeModeTile(),
           ListTile(
             title: Text(context.l10n.backup),

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1285,5 +1285,15 @@
     "whatsNew": "What's New?",
     "withCompletedStatus": "With Completed status",
     "withUnreadChapter": "With unread chapter(s)",
-    "yesterday": "Yesterday"
+    "yesterday": "Yesterday",
+    "history": "History",
+    "searchHistory": "Search history...",
+    "noHistoryFound": "No reading history found",
+    "startReadingToSeeHistory": "Start reading manga to see your history here",
+    "noSearchResults": "No search results",
+    "tryDifferentSearchTerm": "Try a different search term",
+    "errorOccurred": "An error occurred",
+    "viewManga": "View Manga",
+    "removeFromHistory": "Remove from History",
+    "removeFromHistoryConfirmation": "Are you sure you want to remove this chapter from your reading history?"
 }

--- a/lib/src/routes/router_config.dart
+++ b/lib/src/routes/router_config.dart
@@ -12,6 +12,7 @@ import '../features/browse_center/presentation/global_search/global_search_scree
 import '../features/browse_center/presentation/source/source_screen.dart';
 import '../features/browse_center/presentation/source_manga_list/source_manga_list_screen.dart';
 import '../features/browse_center/presentation/source_preference/source_preference_screen.dart';
+import '../features/history/presentation/history_screen.dart';
 import '../features/library/presentation/category/edit_category_screen.dart';
 import '../features/library/presentation/library/library_screen.dart';
 import '../features/manga_book/presentation/downloads/downloads_screen.dart';
@@ -44,6 +45,7 @@ part 'router_config.g.dart';
 part 'sub_routes/browser_routes.dart';
 part 'sub_routes/common_routes.dart';
 part 'sub_routes/downloads_routes.dart';
+part 'sub_routes/history_routes.dart';
 part 'sub_routes/library_routes.dart';
 part 'sub_routes/migration_routes.dart';
 part 'sub_routes/more_routes.dart';
@@ -63,6 +65,8 @@ abstract class Routes {
   static const updates = '/updates';
 
   static const downloads = '/downloads';
+
+  static const history = 'history';
 
   static const extensionRoute = '/extension';
   static const source = '/source';
@@ -163,6 +167,7 @@ GoRouter routerConfig(ref) {
               path: Routes.more,
               routes: [
                 TypedGoRoute<AboutRoute>(path: Routes.about),
+                TypedGoRoute<HistoryRoute>(path: Routes.history),
                 TypedGoRoute<SettingsRoute>(
                   path: Routes.settings,
                   routes: [

--- a/lib/src/routes/sub_routes/history_routes.dart
+++ b/lib/src/routes/sub_routes/history_routes.dart
@@ -1,0 +1,7 @@
+part of '../router_config.dart';
+
+class HistoryRoute extends GoRouteData {
+  const HistoryRoute();
+  @override
+  Widget build(context, state) => const HistoryScreen();
+}


### PR DESCRIPTION
## Summary
Implements a complete reading history feature allowing users to view recently read chapters grouped by date, search through their history, and remove items by marking chapters as unread.

## Key Features
- Reading history display with date grouping (Today, Yesterday, etc.)
- Search across manga titles, chapters, and authors
- Remove from history functionality
- Pagination for large datasets
- Real-time UI updates
- If you click on the chapter itself it opens the reader where you left of. 
- If you want to open the manga page itself it is doable from the 3 dots on the right

## Files Added
- `lib/src/features/history/` - Complete history feature implementation
- Updated navigation, constants, and localization

## Testing Status
- All compilation errors resolved
- `flutter analyze` passes (only existing deprecation warnings)
- Runs as expected in chrome testing & on Android

## Pictures
![image](https://github.com/user-attachments/assets/13592777-64fb-4357-b99a-2b1ae1328004)
![image](https://github.com/user-attachments/assets/0c3342d0-c683-431d-985d-fe31da12959e)
![image](https://github.com/user-attachments/assets/d5b380a3-8d63-4bb5-9b60-375bfe393bce)

## NOTES
- This is purely a app specific feature. Since Suwayomi does not have a delete history function from what i can tell this will only work in the app itself. Even if you click the "Remove from History" button this will mark it as unread in Suwayomi aswell but the chapter will still be under history there if you have it enabled.