### PR TITLE
Fix default reader mode fallback logic

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -199,16 +199,77 @@ class ReaderScreen extends HookConsumerWidget {
                                 showReaderLayoutAnimation,
                             chapterPages: chapterPagesData,
                           ),
-                        ReaderMode.defaultReader ||
-                        null =>
-                          ContinuousReaderMode(
-                            chapter: chapterData,
-                            manga: data,
-                            onPageChanged: onPageChanged,
-                            showReaderLayoutAnimation:
-                                showReaderLayoutAnimation,
-                            chapterPages: chapterPagesData,
-                          )
+                        ReaderMode.defaultReader || null => switch (
+                              defaultReaderMode ?? ReaderMode.webtoon) {
+                            ReaderMode.singleHorizontalLTR =>
+                              SinglePageReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                chapterPages: chapterPagesData,
+                              ),
+                            ReaderMode.singleHorizontalRTL =>
+                              SinglePageReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                reverse: true,
+                                showReaderLayoutAnimation:
+                                    showReaderLayoutAnimation,
+                                chapterPages: chapterPagesData,
+                              ),
+                            ReaderMode.singleVertical => SinglePageReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                scrollDirection: Axis.vertical,
+                                showReaderLayoutAnimation:
+                                    showReaderLayoutAnimation,
+                                chapterPages: chapterPagesData,
+                              ),
+                            ReaderMode.continuousHorizontalLTR =>
+                              ContinuousReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                scrollDirection: Axis.horizontal,
+                                showReaderLayoutAnimation:
+                                    showReaderLayoutAnimation,
+                                chapterPages: chapterPagesData,
+                              ),
+                            ReaderMode.continuousHorizontalRTL =>
+                              ContinuousReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                scrollDirection: Axis.horizontal,
+                                reverse: true,
+                                showReaderLayoutAnimation:
+                                    showReaderLayoutAnimation,
+                                chapterPages: chapterPagesData,
+                              ),
+                            ReaderMode.continuousVertical =>
+                              ContinuousReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                showSeparator: true,
+                                showReaderLayoutAnimation:
+                                    showReaderLayoutAnimation,
+                                chapterPages: chapterPagesData,
+                              ),
+                            ReaderMode.webtoon ||
+                            ReaderMode.defaultReader ||
+                            null =>
+                              ContinuousReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                showReaderLayoutAnimation:
+                                    showReaderLayoutAnimation,
+                                chapterPages: chapterPagesData,
+                              ),
+                          }
                       };
                     },
                   );

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -258,9 +258,7 @@ class ReaderScreen extends HookConsumerWidget {
                                     showReaderLayoutAnimation,
                                 chapterPages: chapterPagesData,
                               ),
-                            ReaderMode.webtoon ||
-                            ReaderMode.defaultReader ||
-                            null =>
+                            ReaderMode.webtoon || _ =>
                               ContinuousReaderMode(
                                 chapter: chapterData,
                                 manga: data,


### PR DESCRIPTION
When manga is set to "Default" reading mode, it was always falling back to webtoon instead of using the user's actual default preference from settings.

Now properly resolves to the user's configured default mode (LTR/RTL/etc) when manga metadata is `defaultReader` or `null`.

Fixes issue where some mangas would randomly display in webtoon mode despite user having LTR set as default.