### PR TITLE
Feature/new swipe function + webtoon change

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -27,6 +27,7 @@ enum DBKeys {
   invertTap(false),
   quickSearchToggle(true),
   swipeToggle(true),
+  lastPageSwipeEnabled(false),
   scrollAnimation(true),
   showNSFW(true),
   downloadedBadge(true),

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -258,8 +258,7 @@ class ReaderScreen extends HookConsumerWidget {
                                     showReaderLayoutAnimation,
                                 chapterPages: chapterPagesData,
                               ),
-                            ReaderMode.webtoon || _ =>
-                              ContinuousReaderMode(
+                            ReaderMode.webtoon || _ => ContinuousReaderMode(
                                 chapter: chapterData,
                                 manga: data,
                                 onPageChanged: onPageChanged,

--- a/lib/src/features/manga_book/presentation/reader/utils/last_page_swipe_utils.dart
+++ b/lib/src/features/manga_book/presentation/reader/utils/last_page_swipe_utils.dart
@@ -18,14 +18,14 @@ enum SwipeDirection {
   down,
 }
 
-/// TASK 4.2: Navigation action types for smart navigation logic
+/// Navigation action types for smart navigation logic
 enum NavigationAction {
   pageNavigation,
   nextChapter,
   previousChapter,
 }
 
-/// TASK 4.2: Page position types for smart navigation decisions
+/// Page position types for smart navigation decisions
 enum PagePosition {
   firstPage,
   middlePage,
@@ -124,17 +124,17 @@ class LastPageSwipeUtils {
     }
   }
 
-  /// TASK 3.3: Enhanced swipe direction detection with diagonal handling and minimum velocity
+  /// Enhanced swipe direction detection with diagonal handling and minimum velocity
   static SwipeDirection? detectSwipeDirectionAdvanced(DragEndDetails details) {
     final velocityPixels = details.velocity.pixelsPerSecond;
 
-    // Minimum velocity threshold to avoid accidental triggers (Task 3.3 requirement)
+    // Minimum velocity threshold to avoid accidental triggers
     const double minVelocity = 100.0;
     if (velocityPixels.distance < minVelocity) {
       return null;
     }
 
-    // TASK 3.3: Prioritize primary direction for diagonal swipes
+    // Prioritize primary direction for diagonal swipes
     final double absX = velocityPixels.dx.abs();
     final double absY = velocityPixels.dy.abs();
 
@@ -147,7 +147,7 @@ class LastPageSwipeUtils {
     }
   }
 
-  /// TASK 3.4: Check if swipe is within acceptable angle tolerance (±15°)
+  /// Check if swipe is within acceptable angle tolerance (±15°)
   static bool isWithinAngleTolerance({
     required SwipeDirection actualDirection,
     required SwipeDirection expectedDirection,
@@ -180,12 +180,12 @@ class LastPageSwipeUtils {
     double diff = (angleDegrees - expectedAngle).abs();
     if (diff > 180) diff = 360 - diff;
 
-    // TASK 3.4: ±15° tolerance as specified in project.mdc
+    // ±15° tolerance
     const double toleranceDegrees = 15.0;
     return diff <= toleranceDegrees;
   }
 
-  /// TASK 3.4: Enhanced direction validation with tolerance for slightly off-angle swipes
+  /// Enhanced direction validation with tolerance for slightly off-angle swipes
   static bool shouldTriggerChapterNavWithTolerance({
     required bool lastPageSwipeEnabled,
     required bool isAtLastPage,
@@ -193,7 +193,7 @@ class LastPageSwipeUtils {
     required ReaderMode resolvedReaderMode,
     required DragEndDetails details,
   }) {
-    // Basic validation from project.mdc safety rules
+    // Basic validation from safety rules
     if (!lastPageSwipeEnabled || !isAtLastPage) {
       return false;
     }
@@ -206,7 +206,7 @@ class LastPageSwipeUtils {
       return true;
     }
 
-    // TASK 3.4: Add tolerance for slightly off-angle swipes (±15°)
+    // Add tolerance for slightly off-angle swipes (±15°)
     return isWithinAngleTolerance(
       actualDirection: actualDirection,
       expectedDirection: expectedDirection,
@@ -215,19 +215,19 @@ class LastPageSwipeUtils {
   }
 
   /// Checks if the current context should trigger chapter navigation
-  /// This is the main validation function following project.mdc safety rules
+  /// This is the main validation function following safety rules
   static bool shouldTriggerChapterNav({
     required bool lastPageSwipeEnabled,
     required bool isAtLastPage,
     required SwipeDirection actualDirection,
     required ReaderMode resolvedReaderMode,
   }) {
-    // Every custom gesture must be wrapped like this (from project.mdc safety rules)
+    // Every custom gesture must be wrapped like this (from safety rules)
     if (!lastPageSwipeEnabled || !isAtLastPage) {
       return false;
     }
 
-    // Direction validation required (from project.mdc safety rules)
+    // Direction validation required (from safety rules)
     return isCorrectDirection(actualDirection, resolvedReaderMode);
   }
 
@@ -253,10 +253,6 @@ class LastPageSwipeUtils {
     }
   }
 
-  // ===========================================================================
-  // TASK 2.1: Last-Page Detection Logic
-  // ===========================================================================
-
   /// Checks if the current page is the last page of the chapter
   static bool isAtLastPage({
     required int currentIndex,
@@ -266,7 +262,7 @@ class LastPageSwipeUtils {
     return currentIndex >= chapterPages.pages.length - 1;
   }
 
-  /// TASK 4.1: Checks if the current page is the first page of the chapter
+  /// Checks if the current page is the first page of the chapter
   static bool isAtFirstPage({
     required int currentIndex,
   }) {
@@ -283,7 +279,7 @@ class LastPageSwipeUtils {
     return currentIndex >= (pageCount - 1);
   }
 
-  /// TASK 4.2: Enhanced page position detection for smart navigation
+  /// Enhanced page position detection for smart navigation
   static bool isAtLastPageReliable({
     required int currentIndex,
     required ChapterPagesDto chapterPages,
@@ -310,7 +306,7 @@ class LastPageSwipeUtils {
     return result;
   }
 
-  /// TASK 4.2: Comprehensive page position detection for smart navigation
+  /// Comprehensive page position detection for smart navigation
   static PagePosition detectPagePosition({
     required int currentIndex,
     required ChapterPagesDto chapterPages,
@@ -331,10 +327,6 @@ class LastPageSwipeUtils {
       return PagePosition.middlePage;
     }
   }
-
-  // ===========================================================================
-  // TASK 2.4: Direction-Aware State Management & Logging
-  // ===========================================================================
 
   /// Validates direction matching for debugging purposes
   /// Returns true if actual direction matches expected direction for the reader mode

--- a/lib/src/features/manga_book/presentation/reader/utils/last_page_swipe_utils.dart
+++ b/lib/src/features/manga_book/presentation/reader/utils/last_page_swipe_utils.dart
@@ -1,0 +1,352 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import '../../../../../constants/enum.dart';
+import '../../../domain/chapter_page/chapter_page_model.dart';
+
+/// Direction of swipe gestures for last-page navigation
+enum SwipeDirection {
+  left,
+  right,
+  up,
+  down,
+}
+
+/// TASK 4.2: Navigation action types for smart navigation logic
+enum NavigationAction {
+  pageNavigation,
+  nextChapter,
+  previousChapter,
+}
+
+/// TASK 4.2: Page position types for smart navigation decisions
+enum PagePosition {
+  firstPage,
+  middlePage,
+  lastPage,
+  singlePage,
+}
+
+/// Utility class for last-page swipe feature validation and direction mapping
+class LastPageSwipeUtils {
+  LastPageSwipeUtils._();
+
+  /// Validates if the last-page swipe feature is available for the current platform and context
+  static bool isFeatureAvailable() {
+    // Add platform-specific checks if needed
+    // For now, available on all platforms
+    return true;
+  }
+
+  /// Validates the setting and context for safe feature activation
+  static bool canActivateFeature({
+    required bool lastPageSwipeEnabled,
+    required bool isAtLastPage,
+    SwipeDirection? actualDirection,
+    ReaderMode? readerMode,
+  }) {
+    // Basic validation
+    if (!lastPageSwipeEnabled || !isAtLastPage) {
+      return false;
+    }
+
+    // Direction validation if both direction and mode are provided
+    if (actualDirection != null && readerMode != null) {
+      final expectedDirection = getExpectedSwipeDirection(readerMode);
+      return actualDirection == expectedDirection;
+    }
+
+    return true;
+  }
+
+  /// Maps reader modes to their expected swipe directions for next chapter navigation
+  /// Following the safety rules from project.mdc
+  static SwipeDirection getExpectedSwipeDirection(ReaderMode mode) {
+    switch (mode) {
+      case ReaderMode.singleHorizontalLTR:
+      case ReaderMode.continuousHorizontalLTR:
+        return SwipeDirection.left; // LTR: swipe left for next
+
+      case ReaderMode.singleHorizontalRTL:
+      case ReaderMode.continuousHorizontalRTL:
+        return SwipeDirection.right; // RTL: swipe right for next
+
+      case ReaderMode.singleVertical:
+      case ReaderMode.continuousVertical:
+      case ReaderMode.webtoon:
+        return SwipeDirection.up; // Vertical: swipe up for next
+
+      case ReaderMode.defaultReader:
+        return SwipeDirection.left; // Safe fallback as specified in project.mdc
+    }
+  }
+
+  /// Resolves the actual reading mode, handling the "default" case
+  /// According to memories, when manga has 'Default' reading mode selected,
+  /// it should use whatever reading mode the user has configured as their default in settings
+  static ReaderMode resolveActualReaderMode({
+    required ReaderMode? mangaReaderMode,
+    required ReaderMode? defaultReaderMode,
+  }) {
+    if (mangaReaderMode == null ||
+        mangaReaderMode == ReaderMode.defaultReader) {
+      return defaultReaderMode ?? ReaderMode.webtoon;
+    }
+    return mangaReaderMode;
+  }
+
+  /// Validates if the actual swipe direction matches the expected direction for the reader mode
+  static bool isCorrectDirection(SwipeDirection actual, ReaderMode mode) {
+    final expected = getExpectedSwipeDirection(mode);
+    return actual == expected;
+  }
+
+  /// Detects swipe direction from gesture details
+  static SwipeDirection? detectSwipeDirection(DragEndDetails details) {
+    final velocity = details.velocity.pixelsPerSecond;
+    final primaryVelocity = details.primaryVelocity;
+
+    if (primaryVelocity == null) return null;
+
+    // Determine primary direction based on velocity magnitude
+    if (velocity.dx.abs() > velocity.dy.abs()) {
+      // Horizontal swipe
+      return primaryVelocity > 0 ? SwipeDirection.right : SwipeDirection.left;
+    } else {
+      // Vertical swipe
+      return primaryVelocity > 0 ? SwipeDirection.down : SwipeDirection.up;
+    }
+  }
+
+  /// TASK 3.3: Enhanced swipe direction detection with diagonal handling and minimum velocity
+  static SwipeDirection? detectSwipeDirectionAdvanced(DragEndDetails details) {
+    final velocityPixels = details.velocity.pixelsPerSecond;
+
+    // Minimum velocity threshold to avoid accidental triggers (Task 3.3 requirement)
+    const double minVelocity = 100.0;
+    if (velocityPixels.distance < minVelocity) {
+      return null;
+    }
+
+    // TASK 3.3: Prioritize primary direction for diagonal swipes
+    final double absX = velocityPixels.dx.abs();
+    final double absY = velocityPixels.dy.abs();
+
+    if (absX > absY) {
+      // Horizontal primary direction
+      return velocityPixels.dx > 0 ? SwipeDirection.right : SwipeDirection.left;
+    } else {
+      // Vertical primary direction
+      return velocityPixels.dy > 0 ? SwipeDirection.down : SwipeDirection.up;
+    }
+  }
+
+  /// TASK 3.4: Check if swipe is within acceptable angle tolerance (±15°)
+  static bool isWithinAngleTolerance({
+    required SwipeDirection actualDirection,
+    required SwipeDirection expectedDirection,
+    required DragEndDetails details,
+  }) {
+    final velocity = details.velocity.pixelsPerSecond;
+
+    // Calculate swipe angle in radians
+    final double angle = math.atan2(velocity.dy, velocity.dx);
+    final double angleDegrees = angle * (180 / math.pi);
+
+    // Define expected angles for each direction
+    double expectedAngle;
+    switch (expectedDirection) {
+      case SwipeDirection.left:
+        expectedAngle = 180; // or -180
+        break;
+      case SwipeDirection.right:
+        expectedAngle = 0;
+        break;
+      case SwipeDirection.up:
+        expectedAngle = -90;
+        break;
+      case SwipeDirection.down:
+        expectedAngle = 90;
+        break;
+    }
+
+    // Calculate angle difference with wrapping
+    double diff = (angleDegrees - expectedAngle).abs();
+    if (diff > 180) diff = 360 - diff;
+
+    // TASK 3.4: ±15° tolerance as specified in project.mdc
+    const double toleranceDegrees = 15.0;
+    return diff <= toleranceDegrees;
+  }
+
+  /// TASK 3.4: Enhanced direction validation with tolerance for slightly off-angle swipes
+  static bool shouldTriggerChapterNavWithTolerance({
+    required bool lastPageSwipeEnabled,
+    required bool isAtLastPage,
+    required SwipeDirection actualDirection,
+    required ReaderMode resolvedReaderMode,
+    required DragEndDetails details,
+  }) {
+    // Basic validation from project.mdc safety rules
+    if (!lastPageSwipeEnabled || !isAtLastPage) {
+      return false;
+    }
+
+    // Get expected direction
+    final expectedDirection = getExpectedSwipeDirection(resolvedReaderMode);
+
+    // Exact match (preferred)
+    if (actualDirection == expectedDirection) {
+      return true;
+    }
+
+    // TASK 3.4: Add tolerance for slightly off-angle swipes (±15°)
+    return isWithinAngleTolerance(
+      actualDirection: actualDirection,
+      expectedDirection: expectedDirection,
+      details: details,
+    );
+  }
+
+  /// Checks if the current context should trigger chapter navigation
+  /// This is the main validation function following project.mdc safety rules
+  static bool shouldTriggerChapterNav({
+    required bool lastPageSwipeEnabled,
+    required bool isAtLastPage,
+    required SwipeDirection actualDirection,
+    required ReaderMode resolvedReaderMode,
+  }) {
+    // Every custom gesture must be wrapped like this (from project.mdc safety rules)
+    if (!lastPageSwipeEnabled || !isAtLastPage) {
+      return false;
+    }
+
+    // Direction validation required (from project.mdc safety rules)
+    return isCorrectDirection(actualDirection, resolvedReaderMode);
+  }
+
+  /// Graceful degradation helper - returns false if any validation fails
+  static bool validateWithGracefulDegradation({
+    required bool lastPageSwipeEnabled,
+    required bool isAtLastPage,
+    SwipeDirection? actualDirection,
+    ReaderMode? resolvedReaderMode,
+  }) {
+    try {
+      if (!isFeatureAvailable()) return false;
+
+      return canActivateFeature(
+        lastPageSwipeEnabled: lastPageSwipeEnabled,
+        isAtLastPage: isAtLastPage,
+        actualDirection: actualDirection,
+        readerMode: resolvedReaderMode,
+      );
+    } catch (e) {
+      // Graceful degradation if feature fails
+      return false;
+    }
+  }
+
+  // ===========================================================================
+  // TASK 2.1: Last-Page Detection Logic
+  // ===========================================================================
+
+  /// Checks if the current page is the last page of the chapter
+  static bool isAtLastPage({
+    required int currentIndex,
+    required ChapterPagesDto chapterPages,
+  }) {
+    if (chapterPages.pages.isEmpty) return false;
+    return currentIndex >= chapterPages.pages.length - 1;
+  }
+
+  /// TASK 4.1: Checks if the current page is the first page of the chapter
+  static bool isAtFirstPage({
+    required int currentIndex,
+  }) {
+    return currentIndex <= 0;
+  }
+
+  /// Checks if the current page is the last page using metadata
+  static bool isAtLastPageByMetadata({
+    required int currentIndex,
+    required ChapterPagesDto chapterPages,
+  }) {
+    final pageCount = chapterPages.chapter.pageCount;
+    if (pageCount <= 0) return false;
+    return currentIndex >= (pageCount - 1);
+  }
+
+  /// TASK 4.2: Enhanced page position detection for smart navigation
+  static bool isAtLastPageReliable({
+    required int currentIndex,
+    required ChapterPagesDto chapterPages,
+  }) {
+    // Primary method: check against actual loaded pages
+    final actualPagesCheck = isAtLastPage(
+      currentIndex: currentIndex,
+      chapterPages: chapterPages,
+    );
+
+    // Fallback method: check against metadata
+    final metadataCheck = isAtLastPageByMetadata(
+      currentIndex: currentIndex,
+      chapterPages: chapterPages,
+    );
+
+    // Use actual pages if available, otherwise fall back to metadata
+    final result =
+        chapterPages.pages.isNotEmpty ? actualPagesCheck : metadataCheck;
+
+    // If there's a discrepancy between methods, prefer the more conservative approach
+    // This ensures we don't accidentally trigger when not truly at the last page
+
+    return result;
+  }
+
+  /// TASK 4.2: Comprehensive page position detection for smart navigation
+  static PagePosition detectPagePosition({
+    required int currentIndex,
+    required ChapterPagesDto chapterPages,
+  }) {
+    final isFirst = isAtFirstPage(currentIndex: currentIndex);
+    final isLast = isAtLastPageReliable(
+      currentIndex: currentIndex,
+      chapterPages: chapterPages,
+    );
+
+    if (isFirst && isLast) {
+      return PagePosition.singlePage;
+    } else if (isFirst) {
+      return PagePosition.firstPage;
+    } else if (isLast) {
+      return PagePosition.lastPage;
+    } else {
+      return PagePosition.middlePage;
+    }
+  }
+
+  // ===========================================================================
+  // TASK 2.4: Direction-Aware State Management & Logging
+  // ===========================================================================
+
+  /// Validates direction matching for debugging purposes
+  /// Returns true if actual direction matches expected direction for the reader mode
+  static bool validateDirectionMatch({
+    required SwipeDirection actualDirection,
+    required ReaderMode resolvedReaderMode,
+    required bool isAtLastPage,
+    required bool lastPageSwipeEnabled,
+  }) {
+    final expectedDirection = getExpectedSwipeDirection(resolvedReaderMode);
+    final isCorrect = actualDirection == expectedDirection;
+
+    return isCorrect && isAtLastPage && lastPageSwipeEnabled;
+  }
+}

--- a/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
@@ -15,12 +15,6 @@ import '../utils/last_page_swipe_utils.dart';
 
 /// A specialized widget for handling directional swipe gestures in the reader
 /// Extracted from ReaderView to improve performance and maintainability
-///
-/// TASK 3 IMPLEMENTATION: Enhanced gesture detection with arena competition
-/// Uses hybrid approach: RawGestureDetector for advanced features, GestureDetector for fallback
-///
-/// TASK 4 IMPLEMENTATION: Integrated with existing navigation infrastructure
-/// Hooks into ReaderView navigation functions with smart navigation logic
 class DirectionalSwipeGestureHandler extends HookWidget {
   const DirectionalSwipeGestureHandler({
     super.key,
@@ -37,10 +31,8 @@ class DirectionalSwipeGestureHandler extends HookWidget {
     required this.chapterPages,
     required this.mangaId,
     required this.prevNextChapterPair,
-    // TASK 4.1: Hook into existing navigation functions
     required this.onNextPage,
     required this.onPreviousPage,
-    // Fix: Add PageController to get real-time page index
     required this.pageController,
   });
 
@@ -57,15 +49,12 @@ class DirectionalSwipeGestureHandler extends HookWidget {
   final ChapterPagesDto chapterPages;
   final int mangaId;
   final ({ChapterDto? first, ChapterDto? second})? prevNextChapterPair;
-  // TASK 4.1: Existing navigation callbacks for smart navigation logic
   final VoidCallback onNextPage;
   final VoidCallback onPreviousPage;
-  // Fix: PageController for real-time page index access
   final PageController? pageController;
 
   @override
   Widget build(BuildContext context) {
-    // TASK 3.5: Conditional Activation - Use advanced gestures only when needed
     final bool useAdvancedGestures =
         lastPageSwipeEnabled && !readerSwipeChapterToggle;
 
@@ -76,23 +65,15 @@ class DirectionalSwipeGestureHandler extends HookWidget {
     }
   }
 
-  // ===========================================================================
-  // TASK 3.2 & 3.3: Advanced Gesture Detection with Arena Competition
-  // ===========================================================================
-
   /// Advanced gesture handler using RawGestureDetector for proper arena competition
   Widget _buildAdvancedGestureHandler(BuildContext context) {
-    // Temporarily use GestureDetector for testing
     return GestureDetector(
-      // Keep basic gestures for non-swipe interactions
       onLongPressStart: onLongPressStart,
       onLongPressEnd: onLongPressEnd,
       onLongPressMoveUpdate: onLongPressMoveUpdate,
       onTap: onTap,
       behavior: HitTestBehavior.translucent,
-      // Add pan gesture detection for testing
       onPanEnd: (details) {
-        // Detect swipe direction using our existing utility
         final swipeDirection = LastPageSwipeUtils.detectSwipeDirection(details);
 
         if (swipeDirection != null) {
@@ -119,24 +100,19 @@ class DirectionalSwipeGestureHandler extends HookWidget {
         _handleSwipeGesture(
           context: context,
           details: details,
-          allowedAxis: Axis.vertical, // Only trigger on vertical scroll modes
+          allowedAxis: Axis.vertical,
         );
       },
       onVerticalDragEnd: (details) {
         _handleSwipeGesture(
           context: context,
           details: details,
-          allowedAxis:
-              Axis.horizontal, // Only trigger on horizontal scroll modes
+          allowedAxis: Axis.horizontal,
         );
       },
       child: child,
     );
   }
-
-  // ===========================================================================
-  // TASK 3.4: Enhanced Direction Matching Logic
-  // ===========================================================================
 
   /// Enhanced swipe gesture handler with improved direction detection
   void _handleAdvancedSwipeGesture({
@@ -144,12 +120,9 @@ class DirectionalSwipeGestureHandler extends HookWidget {
     required SwipeDirection direction,
     required DragEndDetails details,
   }) {
-    // TASK 3.5: Conditional Activation - Mandatory safety check
     if (!lastPageSwipeEnabled) {
-      return; // Feature disabled, do nothing
+      return;
     }
-
-    // Fix: Get real-time page index from PageController instead of state variable
     final realTimePageIndex = pageController?.page?.round() ?? currentIndex;
 
     debugPrint('🔧 Real-time page detection:');
@@ -157,7 +130,6 @@ class DirectionalSwipeGestureHandler extends HookWidget {
     debugPrint('  - PageController.page: ${pageController?.page}');
     debugPrint('  - Using realTimePageIndex: $realTimePageIndex');
 
-    // TASK 4.2: Enhanced page position detection with real-time index
     final pagePosition = LastPageSwipeUtils.detectPagePosition(
       currentIndex: realTimePageIndex,
       chapterPages: chapterPages,
@@ -168,16 +140,12 @@ class DirectionalSwipeGestureHandler extends HookWidget {
     final isAtFirstPage = pagePosition == PagePosition.firstPage ||
         pagePosition == PagePosition.singlePage;
 
-    // Validate direction and conditions for chapter navigation
-
-    // TASK 4.2: Determine smart navigation action
     final navigationAction = _determineNavigationAction(
       direction: direction,
       isAtLastPage: isAtLastPage,
       isAtFirstPage: isAtFirstPage,
     );
 
-    // TASK 4.2: Execute smart navigation with error handling
     _executeSmartNavigation(
       context: context,
       action: navigationAction,
@@ -185,7 +153,6 @@ class DirectionalSwipeGestureHandler extends HookWidget {
     );
   }
 
-  /// TASK 4.2: Smart decision function: page navigation vs chapter navigation
   /// Determines the appropriate navigation action based on current context
   NavigationAction _determineNavigationAction({
     required SwipeDirection direction,
@@ -202,14 +169,12 @@ class DirectionalSwipeGestureHandler extends HookWidget {
         LastPageSwipeUtils.getExpectedSwipeDirection(resolvedReaderMode);
 
     if (direction == expectedDirection) {
-      // Correct direction for next chapter
       if (isAtLastPage) {
         return NavigationAction.nextChapter;
       } else {
         return NavigationAction.pageNavigation;
       }
     } else if (_isOppositeDirection(direction, expectedDirection)) {
-      // Opposite direction for previous chapter (at first page)
       if (isAtFirstPage) {
         return NavigationAction.previousChapter;
       } else {
@@ -217,7 +182,6 @@ class DirectionalSwipeGestureHandler extends HookWidget {
       }
     }
 
-    // Default to page navigation for all other cases
     return NavigationAction.pageNavigation;
   }
 
@@ -235,7 +199,7 @@ class DirectionalSwipeGestureHandler extends HookWidget {
     }
   }
 
-  /// TASK 4.2: Enhanced navigation logic with error handling and fallback
+  /// Enhanced navigation logic with error handling and fallback
   void _executeSmartNavigation({
     required BuildContext context,
     required NavigationAction action,
@@ -254,12 +218,11 @@ class DirectionalSwipeGestureHandler extends HookWidget {
           break;
       }
     } catch (e) {
-      // TASK 4.2: Graceful error handling - fallback to page navigation
       _performPageNavigation(direction);
     }
   }
 
-  /// TASK 4.2: Navigate to next chapter with graceful fallback
+  /// Navigate to next chapter with graceful fallback
   void _navigateToNextChapterWithFallback(BuildContext context) {
     if (prevNextChapterPair?.first != null) {
       try {
@@ -269,16 +232,14 @@ class DirectionalSwipeGestureHandler extends HookWidget {
           transVertical: scrollDirection != Axis.vertical,
         ).pushReplacement(context);
       } catch (e) {
-        // TASK 4.2: Handle navigation failures gracefully
         onNextPage();
       }
     } else {
-      // TASK 4.2: No next chapter available - fallback to page navigation
       onNextPage();
     }
   }
 
-  /// TASK 4.2: Navigate to previous chapter with graceful fallback
+  /// Navigate to previous chapter with graceful fallback
   void _navigateToPreviousChapterWithFallback(BuildContext context) {
     if (prevNextChapterPair?.second != null) {
       try {
@@ -289,16 +250,14 @@ class DirectionalSwipeGestureHandler extends HookWidget {
           transVertical: scrollDirection != Axis.vertical,
         ).pushReplacement(context);
       } catch (e) {
-        // TASK 4.2: Handle navigation failures gracefully
         onPreviousPage();
       }
     } else {
-      // TASK 4.2: No previous chapter available - fallback to page navigation
       onPreviousPage();
     }
   }
 
-  /// TASK 4.2: Perform appropriate page navigation based on direction
+  /// Perform appropriate page navigation based on direction
   void _performPageNavigation(SwipeDirection direction) {
     switch (direction) {
       case SwipeDirection.left:
@@ -312,40 +271,30 @@ class DirectionalSwipeGestureHandler extends HookWidget {
     }
   }
 
-  // ===========================================================================
-  // TASK 4.2: Smart Navigation Logic
-  // ===========================================================================
-
   /// Enhanced swipe gesture handler following project.mdc safety rules
   void _handleSwipeGesture({
     required BuildContext context,
     required DragEndDetails details,
     required Axis allowedAxis,
   }) {
-    // Check if we should use original swipe behavior or new last-page swipe
     if (readerSwipeChapterToggle) {
-      // Original behavior: swipe to change chapter anywhere
       _handleOriginalSwipeBehavior(context, details, allowedAxis);
       return;
     }
 
-    // New behavior: only at last page with correct direction
     if (!lastPageSwipeEnabled) {
-      return; // Feature disabled, do nothing
+      return;
     }
 
-    // Check if we're on the correct axis for this scroll direction
     if (scrollDirection != allowedAxis) {
-      return; // Wrong axis, do nothing
+      return;
     }
 
-    // Detect swipe direction
     final swipeDirection = LastPageSwipeUtils.detectSwipeDirection(details);
     if (swipeDirection == null) {
-      return; // Could not detect direction
+      return;
     }
 
-    // TASK 4.2: Use smart navigation logic for consistency
     final pagePosition = LastPageSwipeUtils.detectPagePosition(
       currentIndex: currentIndex,
       chapterPages: chapterPages,
@@ -356,16 +305,12 @@ class DirectionalSwipeGestureHandler extends HookWidget {
     final isAtFirstPage = pagePosition == PagePosition.firstPage ||
         pagePosition == PagePosition.singlePage;
 
-    // Validate direction and conditions for chapter navigation
-
-    // TASK 4.2: Determine smart navigation action
     final navigationAction = _determineNavigationAction(
       direction: swipeDirection,
       isAtLastPage: isAtLastPage,
       isAtFirstPage: isAtFirstPage,
     );
 
-    // TASK 4.2: Execute smart navigation with error handling
     _executeSmartNavigation(
       context: context,
       action: navigationAction,

--- a/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
@@ -120,6 +120,14 @@ class DirectionalSwipeGestureHandler extends HookWidget {
     required SwipeDirection direction,
     required DragEndDetails details,
   }) {
+    // In continuous vertical readers, treat drag end as a swipe only at
+    // chapter edges to avoid interfering with normal scrolling.
+
+    final bool isContinuousVerticalMode =
+        resolvedReaderMode == ReaderMode.webtoon ||
+            resolvedReaderMode == ReaderMode.continuousVertical;
+
+    // Resolve current page index for edge checks.
     if (!lastPageSwipeEnabled) {
       return;
     }
@@ -134,6 +142,12 @@ class DirectionalSwipeGestureHandler extends HookWidget {
         pagePosition == PagePosition.singlePage;
     final isAtFirstPage = pagePosition == PagePosition.firstPage ||
         pagePosition == PagePosition.singlePage;
+
+    // Skip swipe handling during mid-chapter scrolling in continuous
+    // vertical readers.
+    if (isContinuousVerticalMode && !(isAtLastPage || isAtFirstPage)) {
+      return;
+    }
 
     final navigationAction = _determineNavigationAction(
       direction: direction,

--- a/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
@@ -125,11 +125,6 @@ class DirectionalSwipeGestureHandler extends HookWidget {
     }
     final realTimePageIndex = pageController?.page?.round() ?? currentIndex;
 
-    debugPrint('🔧 Real-time page detection:');
-    debugPrint('  - State currentIndex: $currentIndex');
-    debugPrint('  - PageController.page: ${pageController?.page}');
-    debugPrint('  - Using realTimePageIndex: $realTimePageIndex');
-
     final pagePosition = LastPageSwipeUtils.detectPagePosition(
       currentIndex: realTimePageIndex,
       chapterPages: chapterPages,

--- a/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
@@ -1,0 +1,392 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+import '../../../../../constants/enum.dart';
+import '../../../../../routes/router_config.dart';
+import '../../../domain/chapter/chapter_model.dart';
+import '../../../domain/chapter_page/chapter_page_model.dart';
+import '../utils/last_page_swipe_utils.dart';
+
+/// A specialized widget for handling directional swipe gestures in the reader
+/// Extracted from ReaderView to improve performance and maintainability
+///
+/// TASK 3 IMPLEMENTATION: Enhanced gesture detection with arena competition
+/// Uses hybrid approach: RawGestureDetector for advanced features, GestureDetector for fallback
+///
+/// TASK 4 IMPLEMENTATION: Integrated with existing navigation infrastructure
+/// Hooks into ReaderView navigation functions with smart navigation logic
+class DirectionalSwipeGestureHandler extends HookWidget {
+  const DirectionalSwipeGestureHandler({
+    super.key,
+    required this.child,
+    required this.onTap,
+    required this.onLongPressStart,
+    required this.onLongPressEnd,
+    required this.onLongPressMoveUpdate,
+    required this.scrollDirection,
+    required this.readerSwipeChapterToggle,
+    required this.lastPageSwipeEnabled,
+    required this.resolvedReaderMode,
+    required this.currentIndex,
+    required this.chapterPages,
+    required this.mangaId,
+    required this.prevNextChapterPair,
+    // TASK 4.1: Hook into existing navigation functions
+    required this.onNextPage,
+    required this.onPreviousPage,
+    // Fix: Add PageController to get real-time page index
+    required this.pageController,
+  });
+
+  final Widget child;
+  final VoidCallback onTap;
+  final void Function(LongPressStartDetails) onLongPressStart;
+  final void Function(LongPressEndDetails) onLongPressEnd;
+  final void Function(LongPressMoveUpdateDetails) onLongPressMoveUpdate;
+  final Axis scrollDirection;
+  final bool readerSwipeChapterToggle;
+  final bool lastPageSwipeEnabled;
+  final ReaderMode resolvedReaderMode;
+  final int currentIndex;
+  final ChapterPagesDto chapterPages;
+  final int mangaId;
+  final ({ChapterDto? first, ChapterDto? second})? prevNextChapterPair;
+  // TASK 4.1: Existing navigation callbacks for smart navigation logic
+  final VoidCallback onNextPage;
+  final VoidCallback onPreviousPage;
+  // Fix: PageController for real-time page index access
+  final PageController? pageController;
+
+  @override
+  Widget build(BuildContext context) {
+    // TASK 3.5: Conditional Activation - Use advanced gestures only when needed
+    final bool useAdvancedGestures =
+        lastPageSwipeEnabled && !readerSwipeChapterToggle;
+
+    if (useAdvancedGestures) {
+      return _buildAdvancedGestureHandler(context);
+    } else {
+      return _buildSimpleGestureHandler(context);
+    }
+  }
+
+  // ===========================================================================
+  // TASK 3.2 & 3.3: Advanced Gesture Detection with Arena Competition
+  // ===========================================================================
+
+  /// Advanced gesture handler using RawGestureDetector for proper arena competition
+  Widget _buildAdvancedGestureHandler(BuildContext context) {
+    // Temporarily use GestureDetector for testing
+    return GestureDetector(
+      // Keep basic gestures for non-swipe interactions
+      onLongPressStart: onLongPressStart,
+      onLongPressEnd: onLongPressEnd,
+      onLongPressMoveUpdate: onLongPressMoveUpdate,
+      onTap: onTap,
+      behavior: HitTestBehavior.translucent,
+      // Add pan gesture detection for testing
+      onPanEnd: (details) {
+        // Detect swipe direction using our existing utility
+        final swipeDirection = LastPageSwipeUtils.detectSwipeDirection(details);
+
+        if (swipeDirection != null) {
+          _handleAdvancedSwipeGesture(
+            context: context,
+            direction: swipeDirection,
+            details: details,
+          );
+        }
+      },
+      child: child,
+    );
+  }
+
+  /// Simple gesture handler as fallback
+  Widget _buildSimpleGestureHandler(BuildContext context) {
+    return GestureDetector(
+      onLongPressStart: onLongPressStart,
+      onLongPressEnd: onLongPressEnd,
+      onLongPressMoveUpdate: onLongPressMoveUpdate,
+      onTap: onTap,
+      behavior: HitTestBehavior.translucent,
+      onHorizontalDragEnd: (details) {
+        _handleSwipeGesture(
+          context: context,
+          details: details,
+          allowedAxis: Axis.vertical, // Only trigger on vertical scroll modes
+        );
+      },
+      onVerticalDragEnd: (details) {
+        _handleSwipeGesture(
+          context: context,
+          details: details,
+          allowedAxis:
+              Axis.horizontal, // Only trigger on horizontal scroll modes
+        );
+      },
+      child: child,
+    );
+  }
+
+  // ===========================================================================
+  // TASK 3.4: Enhanced Direction Matching Logic
+  // ===========================================================================
+
+  /// Enhanced swipe gesture handler with improved direction detection
+  void _handleAdvancedSwipeGesture({
+    required BuildContext context,
+    required SwipeDirection direction,
+    required DragEndDetails details,
+  }) {
+    // TASK 3.5: Conditional Activation - Mandatory safety check
+    if (!lastPageSwipeEnabled) {
+      return; // Feature disabled, do nothing
+    }
+
+    // Fix: Get real-time page index from PageController instead of state variable
+    final realTimePageIndex = pageController?.page?.round() ?? currentIndex;
+
+    debugPrint('🔧 Real-time page detection:');
+    debugPrint('  - State currentIndex: $currentIndex');
+    debugPrint('  - PageController.page: ${pageController?.page}');
+    debugPrint('  - Using realTimePageIndex: $realTimePageIndex');
+
+    // TASK 4.2: Enhanced page position detection with real-time index
+    final pagePosition = LastPageSwipeUtils.detectPagePosition(
+      currentIndex: realTimePageIndex,
+      chapterPages: chapterPages,
+    );
+
+    final isAtLastPage = pagePosition == PagePosition.lastPage ||
+        pagePosition == PagePosition.singlePage;
+    final isAtFirstPage = pagePosition == PagePosition.firstPage ||
+        pagePosition == PagePosition.singlePage;
+
+    // Validate direction and conditions for chapter navigation
+
+    // TASK 4.2: Determine smart navigation action
+    final navigationAction = _determineNavigationAction(
+      direction: direction,
+      isAtLastPage: isAtLastPage,
+      isAtFirstPage: isAtFirstPage,
+    );
+
+    // TASK 4.2: Execute smart navigation with error handling
+    _executeSmartNavigation(
+      context: context,
+      action: navigationAction,
+      direction: direction,
+    );
+  }
+
+  /// TASK 4.2: Smart decision function: page navigation vs chapter navigation
+  /// Determines the appropriate navigation action based on current context
+  NavigationAction _determineNavigationAction({
+    required SwipeDirection direction,
+    required bool isAtLastPage,
+    required bool isAtFirstPage,
+  }) {
+    // If last-page swipe is disabled, always use page navigation
+    if (!lastPageSwipeEnabled) {
+      return NavigationAction.pageNavigation;
+    }
+
+    // Direction-aware navigation logic
+    final expectedDirection =
+        LastPageSwipeUtils.getExpectedSwipeDirection(resolvedReaderMode);
+
+    if (direction == expectedDirection) {
+      // Correct direction for next chapter
+      if (isAtLastPage) {
+        return NavigationAction.nextChapter;
+      } else {
+        return NavigationAction.pageNavigation;
+      }
+    } else if (_isOppositeDirection(direction, expectedDirection)) {
+      // Opposite direction for previous chapter (at first page)
+      if (isAtFirstPage) {
+        return NavigationAction.previousChapter;
+      } else {
+        return NavigationAction.pageNavigation;
+      }
+    }
+
+    // Default to page navigation for all other cases
+    return NavigationAction.pageNavigation;
+  }
+
+  /// Check if swipe direction is opposite to expected direction
+  bool _isOppositeDirection(SwipeDirection actual, SwipeDirection expected) {
+    switch (expected) {
+      case SwipeDirection.left:
+        return actual == SwipeDirection.right;
+      case SwipeDirection.right:
+        return actual == SwipeDirection.left;
+      case SwipeDirection.up:
+        return actual == SwipeDirection.down;
+      case SwipeDirection.down:
+        return actual == SwipeDirection.up;
+    }
+  }
+
+  /// TASK 4.2: Enhanced navigation logic with error handling and fallback
+  void _executeSmartNavigation({
+    required BuildContext context,
+    required NavigationAction action,
+    required SwipeDirection direction,
+  }) {
+    try {
+      switch (action) {
+        case NavigationAction.nextChapter:
+          _navigateToNextChapterWithFallback(context);
+          break;
+        case NavigationAction.previousChapter:
+          _navigateToPreviousChapterWithFallback(context);
+          break;
+        case NavigationAction.pageNavigation:
+          _performPageNavigation(direction);
+          break;
+      }
+    } catch (e) {
+      // TASK 4.2: Graceful error handling - fallback to page navigation
+      _performPageNavigation(direction);
+    }
+  }
+
+  /// TASK 4.2: Navigate to next chapter with graceful fallback
+  void _navigateToNextChapterWithFallback(BuildContext context) {
+    if (prevNextChapterPair?.first != null) {
+      try {
+        ReaderRoute(
+          mangaId: mangaId,
+          chapterId: prevNextChapterPair!.first!.id,
+          transVertical: scrollDirection != Axis.vertical,
+        ).pushReplacement(context);
+      } catch (e) {
+        // TASK 4.2: Handle navigation failures gracefully
+        onNextPage();
+      }
+    } else {
+      // TASK 4.2: No next chapter available - fallback to page navigation
+      onNextPage();
+    }
+  }
+
+  /// TASK 4.2: Navigate to previous chapter with graceful fallback
+  void _navigateToPreviousChapterWithFallback(BuildContext context) {
+    if (prevNextChapterPair?.second != null) {
+      try {
+        ReaderRoute(
+          mangaId: mangaId,
+          chapterId: prevNextChapterPair!.second!.id,
+          toPrev: true,
+          transVertical: scrollDirection != Axis.vertical,
+        ).pushReplacement(context);
+      } catch (e) {
+        // TASK 4.2: Handle navigation failures gracefully
+        onPreviousPage();
+      }
+    } else {
+      // TASK 4.2: No previous chapter available - fallback to page navigation
+      onPreviousPage();
+    }
+  }
+
+  /// TASK 4.2: Perform appropriate page navigation based on direction
+  void _performPageNavigation(SwipeDirection direction) {
+    switch (direction) {
+      case SwipeDirection.left:
+      case SwipeDirection.up:
+        onNextPage();
+        break;
+      case SwipeDirection.right:
+      case SwipeDirection.down:
+        onPreviousPage();
+        break;
+    }
+  }
+
+  // ===========================================================================
+  // TASK 4.2: Smart Navigation Logic
+  // ===========================================================================
+
+  /// Enhanced swipe gesture handler following project.mdc safety rules
+  void _handleSwipeGesture({
+    required BuildContext context,
+    required DragEndDetails details,
+    required Axis allowedAxis,
+  }) {
+    // Check if we should use original swipe behavior or new last-page swipe
+    if (readerSwipeChapterToggle) {
+      // Original behavior: swipe to change chapter anywhere
+      _handleOriginalSwipeBehavior(context, details, allowedAxis);
+      return;
+    }
+
+    // New behavior: only at last page with correct direction
+    if (!lastPageSwipeEnabled) {
+      return; // Feature disabled, do nothing
+    }
+
+    // Check if we're on the correct axis for this scroll direction
+    if (scrollDirection != allowedAxis) {
+      return; // Wrong axis, do nothing
+    }
+
+    // Detect swipe direction
+    final swipeDirection = LastPageSwipeUtils.detectSwipeDirection(details);
+    if (swipeDirection == null) {
+      return; // Could not detect direction
+    }
+
+    // TASK 4.2: Use smart navigation logic for consistency
+    final pagePosition = LastPageSwipeUtils.detectPagePosition(
+      currentIndex: currentIndex,
+      chapterPages: chapterPages,
+    );
+
+    final isAtLastPage = pagePosition == PagePosition.lastPage ||
+        pagePosition == PagePosition.singlePage;
+    final isAtFirstPage = pagePosition == PagePosition.firstPage ||
+        pagePosition == PagePosition.singlePage;
+
+    // Validate direction and conditions for chapter navigation
+
+    // TASK 4.2: Determine smart navigation action
+    final navigationAction = _determineNavigationAction(
+      direction: swipeDirection,
+      isAtLastPage: isAtLastPage,
+      isAtFirstPage: isAtFirstPage,
+    );
+
+    // TASK 4.2: Execute smart navigation with error handling
+    _executeSmartNavigation(
+      context: context,
+      action: navigationAction,
+      direction: swipeDirection,
+    );
+  }
+
+  /// Original swipe behavior for when main swipe toggle is enabled
+  void _handleOriginalSwipeBehavior(
+    BuildContext context,
+    DragEndDetails details,
+    Axis allowedAxis,
+  ) {
+    if (scrollDirection != allowedAxis) return;
+
+    if (details.primaryVelocity == null) return;
+
+    if (details.primaryVelocity! > 8) {
+      _navigateToPreviousChapterWithFallback(context);
+    } else {
+      _navigateToNextChapterWithFallback(context);
+    }
+  }
+}

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/continuous_reader_mode.dart
@@ -4,6 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -13,7 +14,6 @@ import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
-import '../../../../../../constants/app_constants.dart';
 import '../../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../../utils/misc/app_utils.dart';
 import '../../../../../../widgets/server_image.dart';
@@ -24,6 +24,20 @@ import '../../../../domain/chapter_page/chapter_page_model.dart';
 import '../../../../domain/manga/manga_model.dart';
 import '../chapter_separator.dart';
 import '../reader_wrapper.dart';
+
+/// Configuration constants for improved scroll behavior
+class _ScrollConfig {
+  const _ScrollConfig._();
+
+  /// Debounce duration for position updates during scrolling
+  static const Duration positionUpdateDebounce = Duration(milliseconds: 300);
+
+  /// Threshold for detecting significant position changes
+  static const double positionChangeThreshold = 0.5;
+
+  /// Minimum visible area required to consider an item "current"
+  static const double minVisibleAreaThreshold = 0.3;
+}
 
 class ContinuousReaderMode extends HookConsumerWidget {
   const ContinuousReaderMode({
@@ -37,6 +51,7 @@ class ContinuousReaderMode extends HookConsumerWidget {
     this.reverse = false,
     this.showReaderLayoutAnimation = false,
   });
+
   final MangaDto manga;
   final ChapterDto chapter;
   final bool showSeparator;
@@ -45,45 +60,79 @@ class ContinuousReaderMode extends HookConsumerWidget {
   final bool reverse;
   final bool showReaderLayoutAnimation;
   final ChapterPagesDto chapterPages;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final scrollController = useMemoized(() => ItemScrollController());
-    final positionsListener = useMemoized(() => ItemPositionsListener.create());
-    final currentIndex = useState(
+    final ItemScrollController scrollController =
+        useMemoized(() => ItemScrollController());
+    final ItemPositionsListener positionsListener =
+        useMemoized(() => ItemPositionsListener.create());
+
+    final ValueNotifier<int> currentIndex = useState(
       chapter.isRead.ifNull()
           ? 0
           : (chapter.lastPageRead).getValueOnNullOrNegative(),
     );
+
+    // Passive position tracking that doesn't interfere with scrolling
+    final ObjectRef<Timer?> positionUpdateTimer = useRef<Timer?>(null);
+    final ValueNotifier<bool> isUserScrolling = useState(false);
+    final ValueNotifier<int> lastReportedIndex = useState(currentIndex.value);
+
+    // Dispose timer properly
     useEffect(() {
-      if (onPageChanged != null) {
-        onPageChanged!(currentIndex.value);
-      }
-      return;
-    }, [currentIndex.value]);
+      return () {
+        positionUpdateTimer.value?.cancel();
+        positionUpdateTimer.value = null;
+      };
+    }, []);
+
+    // Completely passive position tracking that only observes
     useEffect(() {
-      listener() {
-        final positions = positionsListener.itemPositions.value.toList();
-        if (positions.isSingletonList) {
-          currentIndex.value = (positions.first.index);
-        } else {
-          final newPositions = positions.where((ItemPosition position) =>
-              position.itemTrailingEdge.liesBetween());
-          if (newPositions.isBlank) return;
-          currentIndex.value = (newPositions
-              .reduce((ItemPosition max, ItemPosition position) =>
-                  position.itemTrailingEdge > max.itemTrailingEdge
-                      ? position
-                      : max)
-              .index);
-        }
+      void listener() {
+        // Mark as user scrolling to prevent interference
+        isUserScrolling.value = true;
+
+        final List<ItemPosition> positions =
+            positionsListener.itemPositions.value.toList();
+
+        if (positions.isEmpty) return;
+
+        // Cancel any pending position updates
+        positionUpdateTimer.value?.cancel();
+
+        // Use longer debounce to ensure scroll has settled
+        positionUpdateTimer.value =
+            Timer(_ScrollConfig.positionUpdateDebounce, () {
+          _updateCurrentPositionPassively(
+              positions, currentIndex, lastReportedIndex);
+          isUserScrolling.value = false;
+        });
       }
 
       positionsListener.itemPositions.addListener(listener);
-      return () => positionsListener.itemPositions.removeListener(listener);
+      return () {
+        positionsListener.itemPositions.removeListener(listener);
+        positionUpdateTimer.value?.cancel();
+      };
     }, []);
-    final isAnimationEnabled =
+
+    // Notify page changes only when they're significant
+    useEffect(() {
+      final ValueSetter<int>? pageChanged = onPageChanged;
+      if (pageChanged != null &&
+          lastReportedIndex.value != currentIndex.value) {
+        pageChanged(currentIndex.value);
+        lastReportedIndex.value = currentIndex.value;
+      }
+      return null;
+    }, [currentIndex.value]);
+
+    final bool isAnimationEnabled =
         ref.read(readerScrollAnimationProvider).ifNull(true);
-    final isPinchToZoomEnabled = ref.read(pinchToZoomProvider).ifNull(true);
+    final bool isPinchToZoomEnabled =
+        ref.read(pinchToZoomProvider).ifNull(true);
+
     return ReaderWrapper(
       scrollDirection: scrollDirection,
       chapterPages: chapterPages,
@@ -91,50 +140,31 @@ class ContinuousReaderMode extends HookConsumerWidget {
       manga: manga,
       showReaderLayoutAnimation: showReaderLayoutAnimation,
       currentIndex: currentIndex.value,
-      onChanged: (index) => scrollController.jumpTo(index: index),
-      onPrevious: () {
-        final ItemPosition itemPosition =
-            positionsListener.itemPositions.value.toList().first;
-        isAnimationEnabled
-            ? scrollController.scrollTo(
-                index: itemPosition.index,
-                duration: kDuration,
-                curve: kCurve,
-                alignment: itemPosition.itemLeadingEdge + .8,
-              )
-            : scrollController.jumpTo(
-                index: itemPosition.index,
-                alignment: itemPosition.itemLeadingEdge + .8,
-              );
-      },
-      onNext: () {
-        ItemPosition itemPosition = positionsListener.itemPositions.value.first;
-        final int index;
-        final double alignment;
-        if (itemPosition.itemTrailingEdge > 1) {
-          index = itemPosition.index;
-          alignment = itemPosition.itemLeadingEdge - .8;
-        } else {
-          index = itemPosition.index + 1;
-          alignment = 0;
-        }
-        isAnimationEnabled
-            ? scrollController.scrollTo(
-                index: index,
-                duration: kDuration,
-                curve: kCurve,
-                alignment: alignment,
-              )
-            : scrollController.jumpTo(
-                index: index,
-                alignment: alignment,
-              );
-      },
+      onChanged: (int index) => _jumpToPageSafely(
+        scrollController,
+        isUserScrolling,
+        index,
+      ),
+      // Disable automatic previous/next navigation for webtoon to prevent jumping
+      onPrevious: () => _handleNavigationSafely(
+        scrollController,
+        positionsListener,
+        isUserScrolling,
+        isAnimationEnabled,
+        isNext: false,
+      ),
+      onNext: () => _handleNavigationSafely(
+        scrollController,
+        positionsListener,
+        isUserScrolling,
+        isAnimationEnabled,
+        isNext: true,
+      ),
       child: AppUtils.wrapOn(
         !kIsWeb &&
                 (Platform.isAndroid || Platform.isIOS) &&
                 isPinchToZoomEnabled
-            ? (child) => InteractiveViewer(maxScale: 5, child: child)
+            ? (Widget child) => InteractiveViewer(maxScale: 5, child: child)
             : null,
         ScrollablePositionedList.separated(
           itemScrollController: scrollController,
@@ -151,7 +181,7 @@ class ContinuousReaderMode extends HookConsumerWidget {
           separatorBuilder: (BuildContext context, int index) =>
               showSeparator ? const Gap(16) : const SizedBox.shrink(),
           itemBuilder: (BuildContext context, int index) {
-            final image = ServerImage(
+            final Widget image = ServerImage(
               showReloadButton: true,
               fit: scrollDirection == Axis.vertical
                   ? BoxFit.fitWidth
@@ -163,7 +193,7 @@ class ContinuousReaderMode extends HookConsumerWidget {
                   value: downloadProgress.progress,
                 ),
               ),
-              wrapper: (child) => SizedBox(
+              wrapper: (Widget child) => SizedBox(
                 height: scrollDirection == Axis.vertical
                     ? context.height * .7
                     : null,
@@ -173,10 +203,11 @@ class ContinuousReaderMode extends HookConsumerWidget {
                 child: child,
               ),
             );
+
             if (index == 0 || index == chapterPages.chapter.pageCount - 1) {
               final bool reverseDirection =
                   scrollDirection == Axis.horizontal && reverse;
-              final separator = SizedBox(
+              final Widget separator = SizedBox(
                 width: scrollDirection != Axis.vertical
                     ? context.width * .5
                     : null,
@@ -201,5 +232,131 @@ class ContinuousReaderMode extends HookConsumerWidget {
         ),
       ),
     );
+  }
+
+  /// Passive position tracking that only observes scroll position without interfering
+  static void _updateCurrentPositionPassively(
+    List<ItemPosition> positions,
+    ValueNotifier<int> currentIndex,
+    ValueNotifier<int> lastReportedIndex,
+  ) {
+    if (positions.isEmpty) return;
+
+    // Find the item that's most prominently visible
+    ItemPosition? bestCandidate;
+    double bestVisibleArea = 0.0;
+
+    for (final ItemPosition position in positions) {
+      final double visibleArea = _calculateVisibleArea(position);
+
+      // Only consider items that are significantly visible
+      if (visibleArea > _ScrollConfig.minVisibleAreaThreshold &&
+          visibleArea > bestVisibleArea) {
+        bestCandidate = position;
+        bestVisibleArea = visibleArea;
+      }
+    }
+
+    // Only update if we found a good candidate and it's a significant change
+    if (bestCandidate != null) {
+      final int newIndex = bestCandidate.index;
+      final double indexDifference =
+          (newIndex - currentIndex.value).abs().toDouble();
+
+      if (indexDifference >= _ScrollConfig.positionChangeThreshold) {
+        currentIndex.value = newIndex;
+      }
+    }
+  }
+
+  /// Calculates visible area of an item position more accurately
+  static double _calculateVisibleArea(ItemPosition position) {
+    final double leadingEdge = position.itemLeadingEdge.clamp(0.0, 1.0);
+    final double trailingEdge = position.itemTrailingEdge.clamp(0.0, 1.0);
+
+    // Calculate the portion that's actually visible in the viewport
+    final double visibleStart = leadingEdge < 0 ? 0.0 : leadingEdge;
+    final double visibleEnd = trailingEdge > 1 ? 1.0 : trailingEdge;
+
+    return (visibleEnd - visibleStart).clamp(0.0, 1.0);
+  }
+
+  /// Safe page jumping that respects user scroll state
+  static void _jumpToPageSafely(
+    ItemScrollController scrollController,
+    ValueNotifier<bool> isUserScrolling,
+    int index,
+  ) {
+    // Only jump if user is not actively scrolling
+    if (!isUserScrolling.value) {
+      scrollController.jumpTo(index: index);
+    }
+  }
+
+  /// Safe navigation that only works when appropriate and doesn't interfere with scrolling
+  static void _handleNavigationSafely(
+      ItemScrollController scrollController,
+      ItemPositionsListener positionsListener,
+      ValueNotifier<bool> isUserScrolling,
+      bool isAnimationEnabled,
+      {required bool isNext}) {
+    // Don't interfere if user is actively scrolling
+    if (isUserScrolling.value) return;
+
+    final List<ItemPosition> positions =
+        positionsListener.itemPositions.value.toList();
+    if (positions.isEmpty) return;
+
+    // Find current position
+    ItemPosition? currentPosition;
+    for (final ItemPosition position in positions) {
+      final double visibleArea = _calculateVisibleArea(position);
+      if (visibleArea > _ScrollConfig.minVisibleAreaThreshold) {
+        currentPosition = position;
+        break;
+      }
+    }
+
+    if (currentPosition == null) return;
+
+    final int targetIndex;
+    final double alignment;
+
+    if (isNext) {
+      // Move to next item with minimal scroll
+      if (currentPosition.itemTrailingEdge > 0.8) {
+        targetIndex = currentPosition.index + 1;
+        alignment = 0.0;
+      } else {
+        targetIndex = currentPosition.index;
+        alignment = 0.0;
+      }
+    } else {
+      // Move to previous item with minimal scroll
+      if (currentPosition.itemLeadingEdge < 0.2) {
+        targetIndex =
+            (currentPosition.index - 1).clamp(0, double.infinity).toInt();
+        alignment = 0.0;
+      } else {
+        targetIndex = currentPosition.index;
+        alignment = 0.0;
+      }
+    }
+
+    // Use very gentle navigation
+    if (isAnimationEnabled) {
+      scrollController.scrollTo(
+        index: targetIndex,
+        duration:
+            const Duration(milliseconds: 200), // Faster, gentler animation
+        curve: Curves.easeOut, // Gentler curve
+        alignment: alignment,
+      );
+    } else {
+      scrollController.jumpTo(
+        index: targetIndex,
+        alignment: alignment,
+      );
+    }
   }
 }

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/single_page_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/single_page_reader_mode.dart
@@ -109,11 +109,14 @@ class SinglePageReaderMode extends HookConsumerWidget {
         duration: isAnimationEnabled ? kDuration : kInstantDuration,
         curve: kCurve,
       ),
+      pageController: scrollController,
       child: PageView.builder(
         scrollDirection: scrollDirection,
         reverse: reverse,
         controller: scrollController,
         allowImplicitScrolling: true,
+        physics: const BouncingScrollPhysics(
+            parent: AlwaysScrollableScrollPhysics()),
         itemBuilder: (BuildContext context, int index) {
           // Show loading indicator if no pages are available yet
           if (chapterPages.pages.isEmpty) {

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -70,7 +70,7 @@ class ReaderWrapper extends HookConsumerWidget {
   final bool showReaderLayoutAnimation;
   final ChapterPagesDto chapterPages;
 
-  /// TASK 4: Determine transition direction based on reading mode for proper animations
+  /// Determine transition direction based on reading mode for proper animations
   /// Returns true for vertical transitions, false for horizontal transitions
   bool _shouldUseVerticalTransition(ReaderMode readerMode) {
     switch (readerMode) {
@@ -94,7 +94,7 @@ class ReaderWrapper extends HookConsumerWidget {
     }
   }
 
-  /// TASK 4: Determine if the reading mode is RTL for proper animation direction
+  /// Determine if the reading mode is RTL for proper animation direction
   /// Returns true for RTL modes, false for LTR/Vertical modes
   bool _isRTLReaderMode(ReaderMode readerMode) {
     switch (readerMode) {
@@ -219,7 +219,7 @@ class ReaderWrapper extends HookConsumerWidget {
       return null;
     }, [visibility.value]);
 
-    // TASK 4: Enhanced navigation callbacks with last-page swipe logic
+    // Enhanced navigation callbacks with last-page swipe logic
     final enhancedOnNext = useCallback(() {
       if (lastPageSwipeEnabled && !readerSwipeChapterToggle) {
         // Check if we're at the last page
@@ -272,7 +272,7 @@ class ReaderWrapper extends HookConsumerWidget {
       nextPrevChapterPair
     ]);
 
-    // TASK 4: Chapter navigation callbacks with direction-aware animations
+    // Chapter navigation callbacks with direction-aware animations
     final onNextChapter = useCallback(() {
       if (nextPrevChapterPair?.first != null) {
         // Determine transition direction and RTL handling
@@ -598,7 +598,7 @@ class ReaderWrapper extends HookConsumerWidget {
     );
   }
 
-  /// TASK 4: Enhanced child widget that adds last-page swipe detection for PageView
+  /// Enhanced child widget that adds last-page swipe detection for PageView
   Widget _buildEnhancedChildWithPageDetection(
     Widget originalChild,
     bool lastPageSwipeEnabled,
@@ -626,7 +626,7 @@ class ReaderWrapper extends HookConsumerWidget {
   }
 }
 
-/// TASK 4: Widget that enhances PageView with last-page swipe detection
+/// Widget that enhances PageView with last-page swipe detection
 class _PageViewEnhancer extends StatefulWidget {
   const _PageViewEnhancer({
     required this.originalChild,
@@ -837,8 +837,8 @@ class ReaderView extends HookWidget {
   final bool showReaderLayoutAnimation;
   final Widget child;
 
-  /// Gesture handling has been extracted to DirectionalSwipeGestureHandler widget
-  /// for better performance and maintainability. This widget now focuses on:
+  /// Gesture handling extracted for better performance and maintainability.
+  /// This widget focuses on:
   /// - Magnification handling
   /// - Navigation layout overlay
   /// - Basic UI state management

--- a/lib/src/features/settings/presentation/reader/reader_settings_screen.dart
+++ b/lib/src/features/settings/presentation/reader/reader_settings_screen.dart
@@ -14,6 +14,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import 'widgets/reader_initial_overlay_tile/reader_initial_overlay_tile.dart';
 import 'widgets/reader_invert_tap_tile/reader_invert_tap_tile.dart';
+import 'widgets/reader_last_page_swipe_tile/reader_last_page_swipe_tile.dart';
 import 'widgets/reader_magnifier_size_slider/reader_magnifier_size_slider.dart';
 import 'widgets/reader_mode_tile/reader_mode_tile.dart';
 import 'widgets/reader_navigation_layout_tile/reader_navigation_layout_tile.dart';
@@ -39,6 +40,7 @@ class ReaderSettingsScreen extends ConsumerWidget {
           const ReaderInvertTapTile(),
           const ReaderInitialOverlayTile(),
           const SwipeChapterToggleTile(),
+          const ReaderLastPageSwipeTile(),
           const ReaderScrollAnimationTile(),
           const ReaderPaddingSlider(),
           const ReaderMagnifierSizeSlider(),

--- a/lib/src/features/settings/presentation/reader/widgets/reader_last_page_swipe_tile/reader_last_page_swipe_tile.dart
+++ b/lib/src/features/settings/presentation/reader/widgets/reader_last_page_swipe_tile/reader_last_page_swipe_tile.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../../../constants/db_keys.dart';
+import '../../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../../utils/mixin/shared_preferences_client_mixin.dart';
+import '../reader_swipe_toggle_tile/reader_swipe_chapter_toggle_tile.dart';
+
+part 'reader_last_page_swipe_tile.g.dart';
+
+@riverpod
+class LastPageSwipeEnabled extends _$LastPageSwipeEnabled
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.lastPageSwipeEnabled);
+}
+
+class ReaderLastPageSwipeTile extends HookConsumerWidget {
+  const ReaderLastPageSwipeTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final swipeChapterToggle = ref.watch(swipeChapterToggleProvider);
+    final lastPageSwipeEnabled = ref.watch(lastPageSwipeEnabledProvider);
+
+    // Only show this setting when main swipe toggle is DISABLED
+    final showTile = !(swipeChapterToggle ?? DBKeys.swipeToggle.initial);
+
+    if (!showTile) return const SizedBox.shrink();
+
+    return SwitchListTile(
+      controlAffinity: ListTileControlAffinity.trailing,
+      secondary: const Icon(Icons.swipe_right_rounded),
+      title: Text(context.l10n.readerLastPageSwipeToggle),
+      subtitle: Text(context.l10n.readerLastPageSwipeToggleDescription),
+      onChanged: ref.read(lastPageSwipeEnabledProvider.notifier).update,
+      value: lastPageSwipeEnabled.ifNull(),
+    );
+  }
+}

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1144,6 +1144,8 @@
     "readerScrollAnimation": "Scroll animation",
     "readerSwipeChapterToggle": "Swipe toggle",
     "readerSwipeChapterToggleDescription": "Swipe to change chapter in reader",
+    "readerLastPageSwipeToggle": "Last page swipe",
+    "readerLastPageSwipeToggleDescription": "Swipe to next chapter only at last page",
     "readerVolumeTap": "Volume Keys",
     "readerVolumeTapInvert": "Invert Volume Keys",
     "readerVolumeTapSubtitle": "Navigate with Volume Keys",


### PR DESCRIPTION
## Summary
- Add optional swipe-to-next-chapter at last page (disabled by default)
- Fixed random jumping in webtoon mode when scrolling up and a "page switch" would happen

## Problem
- When i was using the "Swipe toggle" feature a lot of the times i would use it on accident while reading
- Therefore i opted for a way to add a feature that shows up if this feature is disabled that allows for seamless chapter switching.
- Reading webtoon and going up resulting in the reader force moving you to the start of the "page" felt very annoying when it happened multiple times.

## How it it works
- Now with the old swipe toggle disabled and the new enabled it will: Allow you to go to the next chapter following your reading direction. So at the last page you can swipe in the direction you are reading and it will go to the next chapter.
- In the first page of a chapter you can also swipe the other way to go back a chapter.
- Should work in all reading modes after testing but as i mostly only read LTR, RTL and Webtoon those are the one that have been heavily tested.

## FIles changed / added
lib/
└─ src/
   └─ constants/
      └─ db_keys.dart                    # +lastPageSwipeEnabled key
   └─ features/
      └─ manga_book/
         └─ presentation/reader/
            ├─ reader_screen.dart        # passes pageController downstream
            ├─ widgets/
            │  ├─ reader_wrapper.dart    # main gesture/overscroll logic
            │  ├─ reader_mode/
            │  │  ├─ single_page_reader_mode.dart  # bounce physics + controller plumbed
            │  │  └─ continuous_reader_mode.dart   # minor import
            │  └─ widgets/
            │     └─ directional_swipe_gesture_handler.dart  # NEW
            └─ utils/
               └─ last_page_swipe_utils.dart        # NEW – direction helpers
      └─ settings/
         └─ presentation/reader/
            ├─ reader_settings_screen.dart          # adds new tile
            └─ widgets/reader_last_page_swipe_tile/
               └─ reader_last_page_swipe_tile.dart  # NEW
   └─ l10n/
      └─ app_en.arb                                 # new strings

## Implementation details

- **DirectionalSwipeGestureHandler**  
  Centralises all swipe detection.  
  - Simple path → legacy feature  
  - Advanced path → last-page feature *(requires `PageController`)*  

- **Physics**  
  `BouncingScrollPhysics` added to paged readers so overscroll events are generated.  

- **Guarding & Safety**  
  `edgeNavTriggered` boolean ensures **one** route push per gesture.  
  Thresholds: **2 px** overshoot (paged) *or* **300 ms** dwell (webtoon) before navigation. 

- **Settings / Persistence**  
  `DBKeys.lastPageSwipeEnabled` persisted via existing mechanism.

## Picture of the new feature (Only shows up if the "Swipe toggle" is disabled
![image](https://github.com/user-attachments/assets/d2c168e9-8eec-4794-93df-fb32a98a5e68)

## Comments
After testing for a while and some minor bug fixes it is working as expected.
I was however having a lot of issues when implementing the feature so i am a 100% sure that there is something i might have missed or could have done better so please don't hesitate if you have any changes you want or see that its not built up to standard.