### PR TITLE
feat: add option to ignore safe area in reader settings

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -51,6 +51,7 @@ enum DBKeys {
   volumeTapInvert(false),
   hideEmptyCategory(false),
   pinchToZoom(true),
+  readerIgnoreSafeArea(false),
   flexScheme(FlexScheme.material),
   historyEnabled(true),
   historyRetentionDays(90),

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -14,6 +14,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../../../constants/enum.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../history/presentation/history_controller.dart';
+import '../../../settings/presentation/reader/widgets/reader_ignore_safe_area_tile/reader_ignore_safe_area_tile.dart';
 import '../../../settings/presentation/reader/widgets/reader_mode_tile/reader_mode_tile.dart';
 import '../../data/manga_book/manga_book_repository.dart';
 import '../../domain/chapter_batch/chapter_batch_model.dart';
@@ -41,6 +42,7 @@ class ReaderScreen extends HookConsumerWidget {
     final manga = ref.watch(mangaProvider);
     final chapter = ref.watch(chapterProviderWithIndex);
     final defaultReaderMode = ref.watch(readerModeKeyProvider);
+    final ignoreSafeArea = ref.watch(readerIgnoreSafeAreaProvider).ifNull();
 
     final debounce = useRef<Timer?>(null);
 
@@ -121,6 +123,10 @@ class ReaderScreen extends HookConsumerWidget {
       child: ScrollConfiguration(
         behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
         child: SafeArea(
+          top: !ignoreSafeArea,
+          bottom: !ignoreSafeArea,
+          left: !ignoreSafeArea,
+          right: !ignoreSafeArea,
           child: manga.showUiWhenData(
             context,
             (data) {

--- a/lib/src/features/settings/presentation/reader/reader_settings_screen.dart
+++ b/lib/src/features/settings/presentation/reader/reader_settings_screen.dart
@@ -12,6 +12,7 @@ import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../utils/extensions/custom_extensions.dart';
+import 'widgets/reader_ignore_safe_area_tile/reader_ignore_safe_area_tile.dart';
 import 'widgets/reader_initial_overlay_tile/reader_initial_overlay_tile.dart';
 import 'widgets/reader_invert_tap_tile/reader_invert_tap_tile.dart';
 import 'widgets/reader_magnifier_size_slider/reader_magnifier_size_slider.dart';
@@ -43,7 +44,10 @@ class ReaderSettingsScreen extends ConsumerWidget {
           const ReaderPaddingSlider(),
           const ReaderMagnifierSizeSlider(),
           if (!kIsWeb) ...[
-            if (Platform.isAndroid || Platform.isIOS) const ReaderPinchToZoom(),
+            if (Platform.isAndroid || Platform.isIOS) ...[
+              const ReaderPinchToZoom(),
+              const ReaderIgnoreSafeAreaTile(),
+            ],
             if (Platform.isAndroid) ...[
               const ReaderVolumeTapTile(),
               if (isVolumeTapEnabled) const ReaderVolumeTapInvertTile(),

--- a/lib/src/features/settings/presentation/reader/widgets/reader_ignore_safe_area_tile/reader_ignore_safe_area_tile.dart
+++ b/lib/src/features/settings/presentation/reader/widgets/reader_ignore_safe_area_tile/reader_ignore_safe_area_tile.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../../../constants/db_keys.dart';
+import '../../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../../utils/mixin/shared_preferences_client_mixin.dart';
+
+part 'reader_ignore_safe_area_tile.g.dart';
+
+@riverpod
+class ReaderIgnoreSafeArea extends _$ReaderIgnoreSafeArea
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.readerIgnoreSafeArea);
+}
+
+class ReaderIgnoreSafeAreaTile extends HookConsumerWidget {
+  const ReaderIgnoreSafeAreaTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile(
+      controlAffinity: ListTileControlAffinity.trailing,
+      secondary: const Icon(Icons.fullscreen_rounded),
+      title: const Text("Ignore Safe Area"),
+      subtitle: const Text("Allow content to extend into notch and home indicator areas"),
+      onChanged: ref.read(readerIgnoreSafeAreaProvider.notifier).update,
+      value: ref.watch(readerIgnoreSafeAreaProvider).ifNull(),
+    );
+  }
+}


### PR DESCRIPTION
On mobile devices, the reading screen may appear slightly cut off at the top (below the camera notch) and at the bottom. This is due to the default use of the safe area, which ensures content doesn't overlap with system UI elements.

To give users more control over their reading experience, I've added an option called "Ignore Safe Area". When enabled, this setting allows the reading screen to extend fully to the edges of the display, providing a true full-screen experience.

### Example Screenshots:
#### Default View (Safe Area Enabled):
Content is adjusted to avoid the notch and bottom edges.
<img src="https://github.com/user-attachments/assets/3c8659d0-a502-4c35-8604-804a6d66ceff" alt="safe-area-enabled" width="300" style="border: 2px solid white; border-radius: 4px;"/>

#### Settings Option to Disable Safe Area:
Users can toggle the "Ignore Safe Area" setting.
<img src="https://github.com/user-attachments/assets/9c87a3d8-aa22-4bdb-bbe5-31d6ec626c01" alt="ignore-safe-area-options" width="300" style="border: 2px solid white; border-radius: 4px;"/>

#### Full-Screen View (Safe Area Ignored):
Content now fills the entire screen, including areas around the notch and bottom.
<img src="https://github.com/user-attachments/assets/1d07edee-7a25-47bf-9588-1b2e2d2ef2e6" alt="safe-area-ignored" width="300" style="border: 2px solid white; border-radius: 4px;"/>